### PR TITLE
chore: CI 검증 강화 및 Node 버전 로컬 고정

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,10 @@ name: CI
 on:
   pull_request:
   push:
-    branches: [main]
+    branches: [main, develop]
 
 jobs:
-  typecheck:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -20,4 +20,20 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      - run: pnpm run typecheck
+      - run: pnpm run build
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm run lint

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
     "prepare": "husky"
   },
   "packageManager": "pnpm@10.32.1",
+  "engines": {
+    "node": "^22.0.0"
+  },
   "dependencies": {
     "@tanstack/react-query": "^5.101.4",
     "clsx": "^2.1.1",


### PR DESCRIPTION
## Summary

CI가 typecheck만 검증하던 것을 build/lint 병렬 job으로 강화하고, push 트리거에 develop을 추가했다. 로컬 Node 버전도 engines.node + engine-strict로 강제해 CI(Node 22)와의 불일치를 사전에 차단한다.

## Related Issues

- close #3

## PR Point (To Reviewer)

build/lint job이 checkout·pnpm 셋업 스텝을 그대로 반복하는데, GitHub Actions에서 job 간 스텝을 직접 공유할 수 없어 나온 중복이다. job이 2개뿐인 지금은 composite/reusable workflow 도입이 오히려 과할 수 있어 그대로 뒀다 — job이 늘어나면 재검토가 필요하다. Husky pre-push 훅은 의도적으로 추가하지 않았다 (CI가 이미 커버).

## Screenshot

해당 없음

## ETC

없음