### PR TITLE
feat: CODEOWNERS 팀원 등록 및 이슈 생성 시 assignee 자동 할당

### DIFF
--- a/.claude/skills/to-spec/SKILL.md
+++ b/.claude/skills/to-spec/SKILL.md
@@ -16,7 +16,7 @@ The issue tracker and triage label vocabulary should have been provided to you â
 
 Check with the user that these seams match their expectations.
 
-3. Write the spec using the template in [`.github/ISSUE_TEMPLATE/spec.md`](../../../.github/ISSUE_TEMPLATE/spec.md), then publish it to the project issue tracker. Apply the `ready-for-agent` label (already set as the template's default), plus exactly one type label: `bug` if this is a fix, `enhancement` otherwise. `/start-work` reads this label to pick the `fix/issue-{n}` vs `feat/issue-{n}` branch prefix, so every issue needs one.
+3. Write the spec using the template in [`.github/ISSUE_TEMPLATE/spec.md`](../../../.github/ISSUE_TEMPLATE/spec.md), then publish it to the project issue tracker. Apply the `ready-for-agent` label (already set as the template's default), plus exactly one type label: `bug` if this is a fix, `enhancement` otherwise. `/start-work` reads this label to pick the `fix/issue-{n}` vs `feat/issue-{n}` branch prefix, so every issue needs one. Always include `--assignee @me` so the author is automatically assigned to the issue.
 
 Fill each section from what was actually discussed - don't pad a section just to fill it:
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,1 @@
-# TODO: 실제 프로젝트 팀원의 GitHub 아이디로 교체할 것.
-# PR 작성자는 자동으로 리뷰 요청 대상에서 제외되고, 나머지 팀원에게 리뷰가 요청된다.
-#
-# 예: * @teammate1 @teammate2 @teammate3
+* @thwjddlqslek @sohxxny @hamxxn

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -5,6 +5,8 @@ Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all op
 ## Conventions
 
 - **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+  - **Title**: prefix with `feat:`, `fix:`, or `chore:` (docs/tooling/maintenance work with no user-facing behavior change). `chore:` still gets the `enhancement` label and a `feat/issue-{n}` branch — there's no separate GitHub label or branch prefix for it. This prefix is for the issue/branch only — PR titles are free-form (`/ship`) since a PR can span multiple issues or conventions (e.g. `hotfix:`).
+  - **Acceptance criteria**: if the task touches source code, include both `pnpm typecheck` and `pnpm lint` passing — not just one.
 - **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
 - **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
 - **Comment on an issue**: `gh issue comment <number> --body "..."`


### PR DESCRIPTION
## Summary

CODEOWNERS에 팀원 3명을 등록해 PR 리뷰어 자동 할당을 활성화하고, to-spec 스킬 이슈 생성 시 작성자가 assignee로 자동 할당되도록 명시했습니다.

## Related Issues

- close #12

## PR Point (To Reviewer)

특별히 없음

## Screenshot

해당 없음

## ETC

없음