### PR TITLE
feat: 코스 지속시간을 원형으로 보여주는 DurationBadge 컴포넌트 추가

### DIFF
--- a/src/shared/ui/duration-badge/DurationBadge.tsx
+++ b/src/shared/ui/duration-badge/DurationBadge.tsx
@@ -1,0 +1,102 @@
+import { cn } from "@/shared/lib/cn";
+
+const MAX_MINUTES = 60;
+const CENTER = 31;
+const RADIUS = 30;
+const DASH = "0.5 0.5";
+// dash 패턴을 반 칸 밀어서 12시 지점에 이음새 점이 정중앙에 오게 한다.
+const DASH_OFFSET = 0.25;
+
+// 각도(0=12시, 시계방향)를 링 위의 좌표로 변환해 반환한다.
+function polarToCartesian(angleDeg: number) {
+  const angleRad = ((angleDeg - 90) * Math.PI) / 180;
+  return {
+    x: CENTER + RADIUS * Math.cos(angleRad),
+    y: CENTER + RADIUS * Math.sin(angleRad),
+  };
+}
+
+// 두 각도 사이를 잇는 원호의 SVG path d 값을 반환한다. (360도 전체는 <circle>로 처리)
+function describeArc(startAngle: number, endAngle: number) {
+  const start = polarToCartesian(startAngle);
+  const end = polarToCartesian(endAngle);
+  const largeArcFlag = endAngle - startAngle <= 180 ? 0 : 1;
+  return `M ${start.x} ${start.y} A ${RADIUS} ${RADIUS} 0 ${largeArcFlag} 1 ${end.x} ${end.y}`;
+}
+
+type DurationBadgeProps = {
+  minutes: number;
+  className?: string;
+};
+
+export default function DurationBadge({ minutes, className }: DurationBadgeProps) {
+  if (minutes > MAX_MINUTES) {
+    throw new Error(
+      `DurationBadge: minutes는 ${MAX_MINUTES} 이하여야 합니다 (받은 값: ${minutes})`,
+    );
+  }
+
+  // minutes 반올림
+  const displayMinutes = Math.round(minutes);
+
+  // 파란 아크 길이는 minutes/60에 비례
+  const fraction = Math.max(displayMinutes, 0) / MAX_MINUTES;
+  const sweepDeg = fraction * 360;
+  const bluePathLength = fraction * 100;
+  const grayPathLength = 100 - bluePathLength;
+
+  return (
+    <div
+      className={cn(
+        "inline-flex h-[6.2rem] w-[6.2rem] items-center justify-center rounded-full bg-gray-10 p-[0.6rem]",
+        className,
+      )}
+    >
+      <div className="relative h-full w-full">
+        <svg
+          viewBox="0 0 62 62"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+          className="absolute inset-0 h-full w-full"
+        >
+          {sweepDeg > 0 &&
+            (sweepDeg >= 360 ? (
+              <circle
+                cx={CENTER}
+                cy={CENTER}
+                r={RADIUS}
+                className="stroke-secondary-200"
+                strokeWidth="2"
+                strokeDasharray={DASH}
+                strokeDashoffset={DASH_OFFSET}
+                pathLength={100}
+              />
+            ) : (
+              <path
+                d={describeArc(0, sweepDeg)}
+                className="stroke-secondary-200"
+                strokeWidth="2"
+                strokeDasharray={DASH}
+                strokeDashoffset={DASH_OFFSET}
+                pathLength={bluePathLength}
+              />
+            ))}
+          {sweepDeg < 360 && (
+            <path
+              d={describeArc(sweepDeg, 360)}
+              className="stroke-gray-60"
+              strokeWidth="2"
+              strokeDasharray={DASH}
+              strokeDashoffset={DASH_OFFSET}
+              pathLength={grayPathLength}
+            />
+          )}
+        </svg>
+        <div className="absolute inset-0 flex items-center justify-center px-[1rem] py-[1.4rem] leading-none text-white">
+          <span className="typo-title-2-regular leading-none">{displayMinutes}</span>
+          <span className="typo-headline-regular leading-none">분</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/shared/ui/duration-badge/DurationBadge.tsx
+++ b/src/shared/ui/duration-badge/DurationBadge.tsx
@@ -93,9 +93,9 @@ export default function DurationBadge({ minutes, className }: DurationBadgeProps
           )}
         </svg>
         <div className="absolute inset-0 flex items-center justify-center px-[1rem] py-[1.4rem] leading-none text-white">
-          <span className="flex items-baseline leading-none">
-            <span className="typo-title-2-5-regular leading-none">{displayMinutes}</span>
-            <span className="typo-headline-regular leading-none">분</span>
+          <span className="flex items-baseline">
+            <span className="typo-title-2-5-regular">{displayMinutes}</span>
+            <span className="typo-headline-regular">분</span>
           </span>
         </div>
       </div>

--- a/src/shared/ui/duration-badge/DurationBadge.tsx
+++ b/src/shared/ui/duration-badge/DurationBadge.tsx
@@ -48,7 +48,7 @@ export default function DurationBadge({ minutes, className }: DurationBadgeProps
   return (
     <div
       className={cn(
-        "inline-flex h-[6.2rem] w-[6.2rem] items-center justify-center rounded-full bg-gray-10 p-[0.6rem]",
+        "inline-flex h-[7.4rem] w-[7.4rem] items-center justify-center rounded-full bg-gray-10 p-[0.6rem]",
         className,
       )}
     >
@@ -93,8 +93,10 @@ export default function DurationBadge({ minutes, className }: DurationBadgeProps
           )}
         </svg>
         <div className="absolute inset-0 flex items-center justify-center px-[1rem] py-[1.4rem] leading-none text-white">
-          <span className="typo-title-2-regular leading-none">{displayMinutes}</span>
-          <span className="typo-headline-regular leading-none">분</span>
+          <span className="flex items-baseline leading-none">
+            <span className="typo-title-2-5-regular leading-none">{displayMinutes}</span>
+            <span className="typo-headline-regular leading-none">분</span>
+          </span>
         </div>
       </div>
     </div>

--- a/src/shared/ui/duration-badge/index.ts
+++ b/src/shared/ui/duration-badge/index.ts
@@ -1,0 +1,1 @@
+export { default as DurationBadge } from "./DurationBadge";


### PR DESCRIPTION
## Summary

`minutes`(분)를 받아 점선 원형 배지로 표시하는 순수 표시용 `DurationBadge`를 추가했다. 파란 아크 길이가 `minutes/60`에 비례해 채워진다(15분→1/4, 30분→1/2, 45분→3/4, 60분→풀서클).

## Related Issues

- close #17

## PR Point (To Reviewer)

- 이슈 본문에는 배경이 50/50 고정 분할, `className`으로 크기 지정이라고 적혀 있지만, 이후 대화에서 Figma를 더 자세히 보고 두 가지를 바꿨다: (1) 링의 파란 부분이 `minutes/60` 비율로 채워지는 진행률 형태라는 걸 확인해서 고정 분할 대신 `describeArc`/`polarToCartesian`로 각도를 계산하도록 구현, (2) 텍스트+패딩(가로 1rem/세로 1.4rem, Figma auto-layout 스펙) 기준 고정 크기(6.2rem)로 바꿔서 더 이상 `className`으로 크기를 지정하지 않는다. 둘 다 의도된 변경이라 이슈 텍스트가 낡은 상태다.
- svgo가 아이콘마다 붙이는 짧은 id 충돌 문제와 비슷하게, 이 컴포넌트도 여러 개를 한 화면에 렌더링하면 파란/회색 dash가 만나는 이음새에서 점이 두 개로 겹쳐 보이는 버그가 있었다. `stroke-dashoffset`으로 dash 위상을 반 칸 밀어서 이음새에 점 하나만 정중앙에 오도록 고쳤다(`DASH_OFFSET`).
- `minutes`가 60을 초과하면 `throw`한다 (에러 바운더리 없는 상태라 렌더링이 그대로 중단됨 — 의도된 동작).
- 색상은 하드코딩 hex 대신 `stroke-secondary-200`/`stroke-gray-60` 토큰 클래스를 쓴다(코드리뷰 반영 — 기존 `--color-secondary-200: #a9def0`, `--color-gray-60: #878a93`와 값이 정확히 일치).
- 코드리뷰 반영: (1) 바깥 원 크기를 `6.2rem` → `7.4rem`으로 키웠다 — 안쪽 패딩(`p-[0.6rem]`)만큼 원이 작아 보였던 문제. (2) 분 숫자 타이포를 `typo-title-2-regular` → `typo-title-2-5-regular`로 수정. (3) 숫자/분 정렬을 `items-center`에서 `items-baseline`으로 바꾸되, 그대로 두면 그룹 전체가 컨테이너 안에서 위로 치우쳐 보여서 숫자/분을 감싸는 wrapper span을 하나 추가해 baseline 정렬은 wrapper 내부에서만 적용하고 바깥은 다시 `items-center`로 wrapper 전체를 가운데 정렬했다.

## Screenshot

<img width="507" height="145" alt="스크린샷 2026-08-08 오후 1 24 09" src="https://github.com/user-attachments/assets/608f0744-801f-4c90-8c58-e5e51f5393dc" />


## ETC

없음
