### PR TITLE
feat: Button에 small 사이즈, secondary/white 색상, isSelected prop 추가

### DIFF
--- a/src/shared/ui/button/base/Button.tsx
+++ b/src/shared/ui/button/base/Button.tsx
@@ -14,6 +14,7 @@ type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
   color?: ButtonColor;
   size?: ButtonSize;
   isLoading?: boolean;
+  isSelected?: boolean;
 };
 
 export default function Button({
@@ -22,6 +23,7 @@ export default function Button({
   size = "large",
   disabled = false,
   isLoading = false,
+  isSelected = false,
   type = "button",
   className,
   ...props
@@ -32,7 +34,8 @@ export default function Button({
       className={cn(
         BUTTON_BASE,
         BUTTON_SIZE[size],
-        BUTTON_COLOR[color],
+        BUTTON_COLOR[color].base,
+        isSelected && BUTTON_COLOR[color].selected,
         disabled && BUTTON_DISABLED,
         className,
       )}

--- a/src/shared/ui/button/base/theme.ts
+++ b/src/shared/ui/button/base/theme.ts
@@ -1,17 +1,33 @@
-export type ButtonColor = "primary" | "tertiary";
-export type ButtonSize = "large" | "medium";
+export type ButtonColor = "primary" | "tertiary" | "secondary" | "white";
+export type ButtonSize = "large" | "medium" | "small";
 
-export const BUTTON_BASE = "flex items-center justify-center typo-body-emphasized";
+export const BUTTON_BASE = "flex items-center justify-center";
 
 export const BUTTON_SIZE: Record<NonNullable<ButtonSize>, string> = {
-  large: "w-full px-6 py-5 rounded-[1.6rem]",
-  medium: "w-[12.4rem] h-[3.8rem] rounded-[0.8rem]",
+  large: "w-full px-6 py-5 rounded-[1.6rem] typo-body-emphasized",
+  medium: "w-[12.4rem] h-[3.8rem] rounded-[0.8rem] typo-body-emphasized",
+  small:
+    "inline-flex h-[4.2rem] gap-[1rem] px-[1.6rem] py-[0.6rem] rounded-[2rem] typo-subheadline-emphasized",
 };
 
 export const BUTTON_DISABLED =
-  "disabled:cursor-not-allowed disabled:bg-gray-95 disabled:text-gray-80";
+  "disabled:cursor-not-allowed disabled:bg-gray-95 disabled:text-gray-80 disabled:border-gray-95 disabled:outline-none";
 
-export const BUTTON_COLOR: Record<NonNullable<ButtonColor>, string> = {
-  primary: "bg-gray-10 text-white active:text-gray-40",
-  tertiary: "bg-tertiary-700 text-primary-200 active:text-primary-700",
+type ButtonColorTheme = {
+  base: string;
+  selected?: string;
+};
+
+export const BUTTON_COLOR: Record<NonNullable<ButtonColor>, ButtonColorTheme> = {
+  primary: { base: "bg-gray-10 text-white active:text-gray-40" },
+  tertiary: { base: "bg-tertiary-700 text-primary-200 active:text-primary-700" },
+  secondary: {
+    base: "bg-bg-surface text-gray-10 border-[1px] border-border-base active:bg-primary-50",
+    selected:
+      "bg-primary-50 border-accent-base outline outline-[1px] outline-accent-base outline-offset-0",
+  },
+  white: {
+    base: "bg-white text-gray-50",
+    selected: "bg-gray-10 text-white",
+  },
 };


### PR DESCRIPTION
## Summary

퀴즈 답안 선택 버튼 같은 선택지 UI에 쓸 `Button`의 `small` 사이즈와 `secondary`/`white` 색상, `isSelected` prop을 추가했다. `BUTTON_COLOR`를 색상별 `{ base, selected? }` 구조로 바꿔 select 스타일을 색상마다 선택적으로 정의할 수 있게 했다.

## Related Issues

- close #21

## PR Point (To Reviewer)

- `secondary`의 select 상태는 스펙상 `border: 2px solid`지만, border-width를 상태별로 바꾸면 `inline-flex`인 `small`처럼 폭이 콘텐츠에 맞춰지는 사이즈에서 토글할 때마다 버튼 크기가 같이 바뀌는 버그가 있었다. border는 1px로 고정하고 outline 1px을 겹쳐 시각적으로 2px 두께를 내는 방식으로 바꿔서 레이아웃엔 영향이 없게 했다 (`theme.ts` 주석 참고).
- `disabled` 상태가 `selected`/색상과 무관하게 항상 무채색으로 보이도록 `BUTTON_DISABLED`에 `border`/`outline` 오버라이드를 추가했다 — 기존엔 `secondary`+`isSelected`+`disabled` 조합에서 accent 색 테두리가 disabled 배경 위에 그대로 남는 문제가 있었다.

## Screenshot
<img width="815" height="678" alt="스크린샷 2026-08-09 오후 5 33 37" src="https://github.com/user-attachments/assets/753a71f3-e5e8-4376-b22f-8c3e9ea859c4" />


## ETC

없음