### PR TITLE
feat: 요일별 스트릭 표시용 CheckMarkGroup 컴포넌트 추가

### DIFF
--- a/src/pages/home/ui/HomePage.tsx
+++ b/src/pages/home/ui/HomePage.tsx
@@ -1,47 +1,7 @@
-import { CheckMarkGroup } from "@/shared/ui/check-mark";
-
-const WEEK_DAYS = [
-  { label: "월", isChecked: true },
-  { label: "화", isChecked: true },
-  { label: "수", isChecked: true },
-  { label: "목", isChecked: true },
-  { label: "금", isChecked: true },
-  { label: "토", isChecked: false },
-  { label: "일", isChecked: false },
-];
-
 export function HomePage() {
   return (
-    <main className="flex min-h-screen flex-col items-center gap-[3.2rem] p-[3.2rem]">
+    <main className="flex min-h-screen items-center justify-center">
       <h1 className="text-2xl font-semibold">ALIGNER</h1>
-
-      <section className="flex w-full flex-col gap-[1.6rem]">
-        <h2 className="typo-headline-emphasized">CheckMarkGroup (요일 스트릭)</h2>
-        <div className="rounded-[1.6rem] bg-white p-[2rem]">
-          <CheckMarkGroup>
-            {WEEK_DAYS.map((day) => (
-              <CheckMarkGroup.Item key={day.label} isChecked={day.isChecked}>
-                <CheckMarkGroup.Indicator />
-                <CheckMarkGroup.Label label={day.label} />
-              </CheckMarkGroup.Item>
-            ))}
-          </CheckMarkGroup>
-        </div>
-      </section>
-
-      <section className="flex w-full flex-col gap-[1.6rem]">
-        <h2 className="typo-headline-emphasized">CheckMarkGroup (label 없음)</h2>
-        <div className="rounded-[1.6rem] bg-white p-[2rem]">
-          <CheckMarkGroup>
-            <CheckMarkGroup.Item isChecked={true}>
-              <CheckMarkGroup.Indicator />
-            </CheckMarkGroup.Item>
-            <CheckMarkGroup.Item isChecked={false}>
-              <CheckMarkGroup.Indicator />
-            </CheckMarkGroup.Item>
-          </CheckMarkGroup>
-        </div>
-      </section>
     </main>
   );
 }

--- a/src/pages/home/ui/HomePage.tsx
+++ b/src/pages/home/ui/HomePage.tsx
@@ -1,7 +1,47 @@
+import { CheckMarkGroup } from "@/shared/ui/check-mark";
+
+const WEEK_DAYS = [
+  { label: "월", isChecked: true },
+  { label: "화", isChecked: true },
+  { label: "수", isChecked: true },
+  { label: "목", isChecked: true },
+  { label: "금", isChecked: true },
+  { label: "토", isChecked: false },
+  { label: "일", isChecked: false },
+];
+
 export function HomePage() {
   return (
-    <main className="flex min-h-screen items-center justify-center">
+    <main className="flex min-h-screen flex-col items-center gap-[3.2rem] p-[3.2rem]">
       <h1 className="text-2xl font-semibold">ALIGNER</h1>
+
+      <section className="flex w-full flex-col gap-[1.6rem]">
+        <h2 className="typo-headline-emphasized">CheckMarkGroup (요일 스트릭)</h2>
+        <div className="rounded-[1.6rem] bg-white p-[2rem]">
+          <CheckMarkGroup>
+            {WEEK_DAYS.map((day) => (
+              <CheckMarkGroup.Item key={day.label} isChecked={day.isChecked}>
+                <CheckMarkGroup.Indicator />
+                <CheckMarkGroup.Label label={day.label} />
+              </CheckMarkGroup.Item>
+            ))}
+          </CheckMarkGroup>
+        </div>
+      </section>
+
+      <section className="flex w-full flex-col gap-[1.6rem]">
+        <h2 className="typo-headline-emphasized">CheckMarkGroup (label 없음)</h2>
+        <div className="rounded-[1.6rem] bg-white p-[2rem]">
+          <CheckMarkGroup>
+            <CheckMarkGroup.Item isChecked={true}>
+              <CheckMarkGroup.Indicator />
+            </CheckMarkGroup.Item>
+            <CheckMarkGroup.Item isChecked={false}>
+              <CheckMarkGroup.Indicator />
+            </CheckMarkGroup.Item>
+          </CheckMarkGroup>
+        </div>
+      </section>
     </main>
   );
 }

--- a/src/shared/assets/icons/mono/check.svg
+++ b/src/shared/assets/icons/mono/check.svg
@@ -1,0 +1,3 @@
+<svg width="34" height="34" viewBox="0 0 34 34" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M13 17.3L15.8 20L21 14.2" stroke="#E6FF01" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/shared/ui/check-mark/CheckMarkGroup.tsx
+++ b/src/shared/ui/check-mark/CheckMarkGroup.tsx
@@ -1,0 +1,84 @@
+import type { HTMLAttributes } from "react";
+import { cn } from "@/shared/lib/cn";
+import { CheckIcon } from "@/shared/ui/icons";
+import { CheckMarkItemContext, useCheckMarkItemContext } from "./context";
+import { CHECK_MARK_BASE, CHECK_MARK_INDICATOR_BG, CHECK_MARK_LABEL_TEXT } from "./theme";
+
+type CheckMarkGroupRootProps = HTMLAttributes<HTMLDivElement>;
+
+function CheckMarkGroupRoot({ className, children, ...props }: CheckMarkGroupRootProps) {
+  return (
+    <div className={cn(CHECK_MARK_BASE.GROUP_BASE, className)} {...props}>
+      {children}
+    </div>
+  );
+}
+
+type CheckMarkGroupItemProps = HTMLAttributes<HTMLDivElement> & {
+  isChecked: boolean;
+};
+
+function CheckMarkGroupItem({ isChecked, className, children, ...props }: CheckMarkGroupItemProps) {
+  return (
+    <CheckMarkItemContext.Provider value={isChecked}>
+      <div className={cn(CHECK_MARK_BASE.ITEM_BASE, className)} {...props}>
+        {children}
+      </div>
+    </CheckMarkItemContext.Provider>
+  );
+}
+
+type CheckMarkGroupIndicatorProps = HTMLAttributes<HTMLDivElement>;
+
+function CheckMarkGroupIndicator({ className, ...props }: CheckMarkGroupIndicatorProps) {
+  const isChecked = useCheckMarkItemContext();
+
+  return (
+    <div
+      aria-hidden="true"
+      className={cn(
+        CHECK_MARK_BASE.INDICATOR_SHAPE,
+        CHECK_MARK_INDICATOR_BG[isChecked ? "checked" : "unchecked"],
+        className,
+      )}
+      {...props}
+    >
+      {isChecked && <CheckIcon className={CHECK_MARK_BASE.ICON} />}
+    </div>
+  );
+}
+
+type CheckMarkGroupLabelProps = Omit<HTMLAttributes<HTMLSpanElement>, "children"> & {
+  label: string;
+};
+
+function CheckMarkGroupLabel({ label, className, ...props }: CheckMarkGroupLabelProps) {
+  const isChecked = useCheckMarkItemContext();
+
+  return (
+    <span
+      className={cn(
+        CHECK_MARK_BASE.LABEL_BASE,
+        CHECK_MARK_LABEL_TEXT[isChecked ? "checked" : "unchecked"],
+        className,
+      )}
+      {...props}
+    >
+      {label}
+    </span>
+  );
+}
+
+type CheckMarkGroupComponent = typeof CheckMarkGroupRoot & {
+  Item: typeof CheckMarkGroupItem;
+  Indicator: typeof CheckMarkGroupIndicator;
+  Label: typeof CheckMarkGroupLabel;
+};
+
+const CheckMarkGroup: CheckMarkGroupComponent = Object.assign(CheckMarkGroupRoot, {
+  Item: CheckMarkGroupItem,
+  Indicator: CheckMarkGroupIndicator,
+  Label: CheckMarkGroupLabel,
+});
+
+export default CheckMarkGroup;

--- a/src/shared/ui/check-mark/CheckMarkGroup.tsx
+++ b/src/shared/ui/check-mark/CheckMarkGroup.tsx
@@ -1,4 +1,4 @@
-import type { HTMLAttributes } from "react";
+import type { DOMAttributes, HTMLAttributes } from "react";
 import { cn } from "@/shared/lib/cn";
 import { CheckIcon } from "@/shared/ui/icons";
 import { CheckMarkItemContext, useCheckMarkItemContext } from "./context";
@@ -28,7 +28,10 @@ function CheckMarkGroupItem({ isChecked, className, children, ...props }: CheckM
   );
 }
 
-type CheckMarkGroupIndicatorProps = HTMLAttributes<HTMLDivElement>;
+type CheckMarkGroupIndicatorProps = Omit<
+  HTMLAttributes<HTMLDivElement>,
+  keyof DOMAttributes<HTMLDivElement>
+>;
 
 function CheckMarkGroupIndicator({ className, ...props }: CheckMarkGroupIndicatorProps) {
   const isChecked = useCheckMarkItemContext();
@@ -48,7 +51,10 @@ function CheckMarkGroupIndicator({ className, ...props }: CheckMarkGroupIndicato
   );
 }
 
-type CheckMarkGroupLabelProps = Omit<HTMLAttributes<HTMLSpanElement>, "children"> & {
+type CheckMarkGroupLabelProps = Omit<
+  HTMLAttributes<HTMLSpanElement>,
+  keyof DOMAttributes<HTMLSpanElement>
+> & {
   label: string;
 };
 

--- a/src/shared/ui/check-mark/context.ts
+++ b/src/shared/ui/check-mark/context.ts
@@ -1,0 +1,11 @@
+import { createContext, useContext } from "react";
+
+export const CheckMarkItemContext = createContext<boolean | null>(null);
+
+export function useCheckMarkItemContext(): boolean {
+  const context = useContext(CheckMarkItemContext);
+  if (context === null) {
+    throw new Error("CheckMarkGroup.Indicator/Label must be used within CheckMarkGroup.Item");
+  }
+  return context;
+}

--- a/src/shared/ui/check-mark/index.ts
+++ b/src/shared/ui/check-mark/index.ts
@@ -1,0 +1,1 @@
+export { default as CheckMarkGroup } from "./CheckMarkGroup";

--- a/src/shared/ui/check-mark/theme.ts
+++ b/src/shared/ui/check-mark/theme.ts
@@ -1,0 +1,20 @@
+export const CHECK_MARK_BASE = {
+  GROUP_BASE: "flex gap-[0.9rem]",
+  ITEM_BASE: "flex flex-col items-center gap-[0.6rem]",
+  INDICATOR_SHAPE: "flex w-[3.4rem] h-[3.4rem] items-center justify-center rounded-full",
+  ICON: "w-[3.4rem] h-[3.4rem] text-primary-500",
+  //현재 폰트 정해지지 x
+  LABEL_BASE: "",
+};
+
+type CheckedState = "checked" | "unchecked";
+
+export const CHECK_MARK_INDICATOR_BG: Record<CheckedState, string> = {
+  checked: "bg-gray-10",
+  unchecked: "bg-gray-98 border border-gray-95",
+};
+
+export const CHECK_MARK_LABEL_TEXT: Record<CheckedState, string> = {
+  checked: "text-gray-10",
+  unchecked: "text-gray-90",
+};

--- a/src/shared/ui/check-mark/theme.ts
+++ b/src/shared/ui/check-mark/theme.ts
@@ -3,8 +3,7 @@ export const CHECK_MARK_BASE = {
   ITEM_BASE: "flex flex-col items-center gap-[0.6rem]",
   INDICATOR_SHAPE: "flex w-[3.4rem] h-[3.4rem] items-center justify-center rounded-full",
   ICON: "w-[3.4rem] h-[3.4rem] text-primary-500",
-  //현재 폰트 정해지지 x
-  LABEL_BASE: "",
+  LABEL_BASE: "typo-caption-2-emphasized",
 };
 
 type CheckedState = "checked" | "unchecked";
@@ -16,5 +15,5 @@ export const CHECK_MARK_INDICATOR_BG: Record<CheckedState, string> = {
 
 export const CHECK_MARK_LABEL_TEXT: Record<CheckedState, string> = {
   checked: "text-gray-10",
-  unchecked: "text-gray-90",
+  unchecked: "text-gray-70",
 };

--- a/src/shared/ui/icons/index.ts
+++ b/src/shared/ui/icons/index.ts
@@ -1,5 +1,6 @@
 export { default as AlarmIcon } from "./mono/AlarmIcon";
 export { default as BackArrowIcon } from "./mono/BackArrowIcon";
+export { default as CheckIcon } from "./mono/CheckIcon";
 export { default as CloseIcon } from "./mono/CloseIcon";
 export { default as FireIcon } from "./mono/FireIcon";
 export { default as HumanIcon } from "./mono/HumanIcon";

--- a/src/shared/ui/icons/mono/CheckIcon.tsx
+++ b/src/shared/ui/icons/mono/CheckIcon.tsx
@@ -1,0 +1,24 @@
+import type { SVGProps } from "react";
+import { cn } from "@/shared/lib/cn";
+
+export default function CheckIcon({ className, ...props }: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={34}
+      height={34}
+      fill="none"
+      viewBox="0 0 34 34"
+      className={cn(className)}
+      {...props}
+    >
+      <path
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="m13 17.3 2.8 2.7 5.2-5.8"
+      />
+    </svg>
+  );
+}


### PR DESCRIPTION
## Summary

읽기 전용으로 체크 여부를 나열하는 UI(요일별 스트릭 등)가 필요해서 `shared/ui/check-mark`에 `CheckMarkGroup` 컴파운드 컴포넌트를 추가했다. `CheckIcon`도 함께 추가했다.

## Related Issues

- close #22

## PR Point (To Reviewer)

- 원래 이슈에서는 `Checkbox`라는 이름으로 시작했는데, 클릭 불가능한 순수 표시 컴포넌트(폼 컨트롤 아님, `onClick`/`role=checkbox` 없음)라 `<input type="checkbox">`를 연상시키는 이름을 피하려고 `CheckMarkGroup`으로 바꿨다.
- 이슈의 완료조건 스니펫은 `Item`이 `isChecked`/`label`을 직접 받는 단일 컴포넌트 형태였지만, 구현 중에 `Item`/`Indicator`/`Label` 세 조각으로 분리했다. `Item`이 `isChecked`를 Context로 하위 `Indicator`/`Label`에 전달하는 방식이라, `label` 없이 인디케이터만 쓰거나 `Label`의 텍스트 색을 `isChecked`에 따라 다르게 하는 것도 자연스럽게 지원된다. 아래 사용법 참고.
- `CHECK_MARK_BASE.LABEL_BASE`(라벨 타이포 클래스)는 아직 Figma 타이포 토큰이 확정되지 않아 빈 문자열로 남아있다 — 후속 확인 필요.

### 사용법

```tsx
import { CheckMarkGroup } from "@/shared/ui/check-mark";

const WEEK_DAYS = [
  { label: "월", isChecked: true },
  { label: "화", isChecked: true },
  { label: "토", isChecked: false },
  { label: "일", isChecked: false },
];

function WeekStreak() {
  return (
    <CheckMarkGroup>
      {WEEK_DAYS.map((day) => (
        <CheckMarkGroup.Item key={day.label} isChecked={day.isChecked}>
          <CheckMarkGroup.Indicator />
          <CheckMarkGroup.Label label={day.label} />
        </CheckMarkGroup.Item>
      ))}
    </CheckMarkGroup>
  );
}

// label 없이 인디케이터만 쓰는 것도 가능
<CheckMarkGroup>
  <CheckMarkGroup.Item isChecked={true}>
    <CheckMarkGroup.Indicator />
  </CheckMarkGroup.Item>
</CheckMarkGroup>;
```

## Screenshot
<img width="366" height="301" alt="스크린샷 2026-08-09 오후 6 34 34" src="https://github.com/user-attachments/assets/ceb126d0-1826-42e5-8596-a0295944793f" />


## ETC

없음