### PR TITLE
feat: Button black CTA variant 추가

### DIFF
--- a/src/app/layouts/Layout.tsx
+++ b/src/app/layouts/Layout.tsx
@@ -6,7 +6,7 @@ type LayoutProps = {
 
 export function Layout({ children }: LayoutProps) {
   return (
-    <div className="mx-auto w-full bg-gray-99 min-h-screen max-w-(--container-max-width) px-[2rem]">
+    <div className="mx-auto w-full bg-gray-99 min-h-screen max-w-(--container-max-width)">
       {children}
     </div>
   );

--- a/src/shared/ui/button/base/Button.tsx
+++ b/src/shared/ui/button/base/Button.tsx
@@ -36,7 +36,7 @@ export default function Button({
         BUTTON_SIZE[size],
         BUTTON_COLOR[color].base,
         isSelected && BUTTON_COLOR[color].selected,
-        disabled && BUTTON_DISABLED,
+        disabled && (BUTTON_COLOR[color].disabled ?? BUTTON_DISABLED),
         className,
       )}
       disabled={disabled}

--- a/src/shared/ui/button/base/theme.ts
+++ b/src/shared/ui/button/base/theme.ts
@@ -1,4 +1,4 @@
-export type ButtonColor = "primary" | "tertiary" | "secondary" | "white";
+export type ButtonColor = "primary" | "tertiary" | "secondary" | "white" | "black";
 export type ButtonSize = "large" | "medium" | "small";
 
 export const BUTTON_BASE = "flex items-center justify-center";
@@ -16,6 +16,7 @@ export const BUTTON_DISABLED =
 type ButtonColorTheme = {
   base: string;
   selected?: string;
+  disabled?: string;
 };
 
 export const BUTTON_COLOR: Record<NonNullable<ButtonColor>, ButtonColorTheme> = {
@@ -29,5 +30,10 @@ export const BUTTON_COLOR: Record<NonNullable<ButtonColor>, ButtonColorTheme> = 
   white: {
     base: "bg-white text-gray-50",
     selected: "bg-gray-10 text-white",
+  },
+  black: {
+    base: "bg-gray-20 text-gray-98 active:bg-accent-base active:text-ink-base",
+    disabled:
+      "disabled:cursor-not-allowed disabled:bg-gray-5 disabled:text-gray-50 disabled:outline-none",
   },
 };


### PR DESCRIPTION
## Summary

Figma에 추가된 `button_CTA_black_background`(node `854:4016`) 디자인에 맞춰 `Button`에 `black` color variant를 추가했다. 기존 `primary`와 톤이 다르고(`gray-20` 배경), pressed 시 배경이 `accent-base`로 전환되며, disabled 시 공용 스타일과 다른 색을 쓴다.

## Related Issues

- close #45

## PR Point (To Reviewer)

`black`의 disabled 색(`gray-5`/`gray-50`)이 다른 색상의 공용 `BUTTON_DISABLED`(밝은 회색)와 달라서, `ButtonColorTheme`에 `disabled?: string`을 추가해 색상별 override가 가능하도록 확장했다. 값이 없으면 기존 공용 스타일로 fallback하므로 다른 색상(`primary`/`tertiary`/`secondary`/`white`)의 동작은 그대로다. 이 override 패턴이 처음 생기는 케이스라 구조가 적절한지 의견 있으면 알려달라.

## Screenshot

<img width="352" height="213" alt="스크린샷 2026-08-15 오후 5 35 15" src="https://github.com/user-attachments/assets/b1868545-bc83-400a-a3c1-bbec7b744bbb" />

## ETC

서비스 전체에서 배경 색깔이 4가지 정도 되어서 레이아웃의 패딩을 제거했습니다.