### PR TITLE
feat: shared/api에 ky 기반 HTTP 클라이언트 설계 적용

### DIFF
--- a/docs/adr/0003-ky-http-client-design.md
+++ b/docs/adr/0003-ky-http-client-design.md
@@ -1,0 +1,46 @@
+# ADR-0003. ky 기반 HTTP 클라이언트 설계
+
+- 상태: 결정됨
+- 날짜: 2026-08-15
+- 맥락 소유: `shared/api`
+
+## 맥락
+
+`shared/api/client.ts`에 ky 인스턴스 틀만 있고 실제로 쓰는 곳은 아직 없다(그린필드).
+
+- 서버 에러 응답 스펙은 아직 확정되지 않았다.
+- 인증은 카카오 로그인이다. 인가 코드를 서버에 넘기면 서버가 자체 JWT를 발급해 응답 바디의 `accessToken`으로 내려준다. 이 로그인 요청은 토큰 없이 호출하는 유일한 엔드포인트다.
+
+## 결정
+
+### 1. `baseUrl` 옵션을 그대로 쓴다
+
+이 레포는 `ky@2.0.2`를 쓰는데, v2에서 `prefixUrl`은 `prefix`로 이름이 바뀌었고 `baseUrl`이 표준 URL 해석을 따르는 옵션으로 새로 생겼다. `client.ts`의 `baseUrl`은 오타가 아니라 이미 맞는 옵션이다.
+
+### 2. base URL은 환경변수 하나(`VITE_API_BASE_URL`)로만 관리
+
+별도 상수나 별도 ky 인스턴스를 만들지 않는다. 코드는 항상 `import.meta.env.VITE_API_BASE_URL` 하나만 읽고, 환경별 값은 `.env.*`/배포 설정에서 주입한다.
+
+### 3. 인증 토큰은 `sessionStorage`에 저장하고 `beforeRequest` 훅으로 헤더에 주입한다
+
+- `shared/api/access-token.ts` — `getAccessToken()`/`setAccessToken(token)`/`isAuthenticated()`를 노출한다. 로그인 로직은 `accessToken`을 받아 `setAccessToken`만 호출하면 되고, 로그아웃은 `setAccessToken(null)`. 라우터 가드·UI 분기는 `isAuthenticated()`만 쓰고 토큰 값은 다루지 않는다.
+- `shared/api/hooks/auth-header.ts` — `BeforeRequestHook`. 토큰이 있으면 `Authorization: Bearer <token>` 헤더를 붙인다.
+- `client.ts`의 `hooks.beforeRequest`에 이 훅 하나만 연결한다. `afterResponse`(401 처리)·`beforeRetry`·`beforeError`는 요구사항이 없어 비워둔다.
+
+### 4. 에러는 ky의 `HTTPError`를 그대로 노출한다
+
+`beforeError`에서 커스텀 에러 클래스로 변환하지 않는다. 호출부에서 필요하면 `error.response.json()`으로 직접 파싱한다.
+
+### 5. 호출부에는 `get`/`post`/`put`/`patch`/`delete` 헬퍼 함수 세트를 `api`라는 이름으로 노출한다
+
+ky 인스턴스(`apiClient`)는 export하지 않고, `shared/api/index.ts`가 `api`만 public API로 내보낸다.
+
+```ts
+api.get<Course[]>("courses/today");
+api.post<Course>("courses", { json: payload });
+```
+
+## 결과
+
+- `shared/api` 바깥에는 `api.get/post/put/patch/delete`, `setAccessToken`, `isAuthenticated`만 노출된다.
+- 401 처리(재로그인 유도, 토큰 갱신)와 `beforeError` 변환은 요구사항이 나오면 재검토한다.

--- a/src/shared/api/access-token.ts
+++ b/src/shared/api/access-token.ts
@@ -1,0 +1,14 @@
+const ACCESS_TOKEN_KEY = "accessToken";
+
+export const getAccessToken = () => sessionStorage.getItem(ACCESS_TOKEN_KEY);
+
+export const setAccessToken = (token: string | null) => {
+  if (!token) {
+    sessionStorage.removeItem(ACCESS_TOKEN_KEY);
+    return;
+  }
+
+  sessionStorage.setItem(ACCESS_TOKEN_KEY, token);
+};
+
+export const isAuthenticated = () => getAccessToken() !== null;

--- a/src/shared/api/api.ts
+++ b/src/shared/api/api.ts
@@ -1,0 +1,10 @@
+import type { Input, Options } from "ky";
+import { apiClient } from "./client";
+
+export const api = {
+  get: <T>(url: Input, options?: Options) => apiClient.get(url, options).json<T>(),
+  post: <T>(url: Input, options?: Options) => apiClient.post(url, options).json<T>(),
+  put: <T>(url: Input, options?: Options) => apiClient.put(url, options).json<T>(),
+  patch: <T>(url: Input, options?: Options) => apiClient.patch(url, options).json<T>(),
+  delete: <T>(url: Input, options?: Options) => apiClient.delete(url, options).json<T>(),
+};

--- a/src/shared/api/client.ts
+++ b/src/shared/api/client.ts
@@ -1,6 +1,10 @@
 import ky from "ky";
+import { authHeader } from "./hooks/auth-header";
 
 export const apiClient = ky.create({
   baseUrl: import.meta.env.VITE_API_BASE_URL,
   timeout: 10_000,
+  hooks: {
+    beforeRequest: [authHeader],
+  },
 });

--- a/src/shared/api/hooks/auth-header.ts
+++ b/src/shared/api/hooks/auth-header.ts
@@ -1,0 +1,9 @@
+import type { BeforeRequestHook } from "ky";
+import { getAccessToken } from "../access-token";
+
+export const authHeader: BeforeRequestHook = ({ request }) => {
+  const token = getAccessToken();
+  if (!token) return;
+
+  request.headers.set("Authorization", `Bearer ${token}`);
+};

--- a/src/shared/api/index.ts
+++ b/src/shared/api/index.ts
@@ -1,0 +1,2 @@
+export { api } from "./api";
+export { isAuthenticated, setAccessToken } from "./access-token";


### PR DESCRIPTION
## Summary

ky 인스턴스 위에 `api.get/post/put/patch/delete` 헬퍼 함수 세트와 sessionStorage 기반 인증 토큰 주입 훅을 추가했다. `shared/api` 바깥에는 `api`, `setAccessToken`, `isAuthenticated`만 노출된다.

### 사용 예시

```ts
import { api, isAuthenticated, setAccessToken } from "@/shared/api";

// GET/POST/PUT/PATCH/DELETE
const courses = await api.get<Course[]>("courses/today");
const created = await api.post<Course>("courses", { json: { name: "코스" } });

// 로그인 성공 시 (카카오 인가 코드 교환 응답의 accessToken)
setAccessToken(accessToken);

// 로그아웃
setAccessToken(null);

// 라우터 가드 / UI 분기
if (!isAuthenticated()) {
  // 로그인 페이지로 리다이렉트
}
```

토큰이 설정되면 이후 모든 `api.*` 요청에 `Authorization: Bearer <token>` 헤더가 자동으로 붙는다.

## Related Issues

- close #49

## PR Point (To Reviewer)

- `ky@2.0.2`에서는 `baseUrl` 옵션이 이미 맞는 옵션이라 (v2에서 `prefixUrl` → `prefix`로 개명됨) `client.ts`는 손대지 않았다. 자세한 배경은 ADR-0003 참고.
- 카카오 로그인 자체는 별도 담당자가 구현 예정이라, 이번 PR은 그쪽이 붙일 수 있는 인터페이스(`setAccessToken`, `isAuthenticated`)까지만 준비했다. 로그인 요청/응답, 401 처리, 토큰 갱신 로직은 포함하지 않는다.
- 에러는 ky의 `HTTPError`를 그대로 노출한다 (커스텀 에러 클래스 변환 없음) — 서버 에러 응답 스펙이 아직 확정 전이라 의도적으로 보류했다.

## Screenshot

<!--
| 스크린샷 | 내용 |
|---------|--------|
| 제목 | 이미지 |
| 제목 | 이미지 |
-->
해당 없음

## ETC

없음