### PR TITLE
feat: 마이페이지 및 프로필 편집 화면 UI 구현

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -9,6 +9,7 @@
 | Indicator | 다단계 플로우에서 현재 몇 번째 단계인지 보여주는 세그먼트 진행 표시. 채워진 칸 수 = 현재 단계 | `shared/ui/indicator`. 단계 수는 `total`로 가변 |
 | OptionItem | 사용자가 여러 선택지 중 하나를 고를 때 쓰는 원형 이미지 아이템. 선택 여부는 부모가 소유한다 | `shared/ui/option-item`. 나열 컨테이너는 쓰는 쪽(feature)에서 만든다 |
 | NumberField | 숫자를 크게 표시하며 입력받는 단일 라인 입력 필드. suffix로 단위 표시, error로 에러 상태 외부 제어 | `shared/ui/number-field` |
+| TextField | 자유 텍스트(한글/영문/숫자 등)를 입력받는 단일 라인 입력 필드. NumberField와 달리 숫자로 필터링하지 않고, 가운데 정렬이 아닌 왼쪽 정렬. error로 에러 상태 외부 제어 | `shared/ui/text-field` |
 | ProgressRingItem | 원형 이미지 둘레를 진행 비율만큼 링으로 칠하고, 아래에 이름과 배지를 붙이는 아이템. `current=0`은 미시작(링·배지 없음), `current=total`은 완료 강조 | `shared/ui/progress-ring-item`. 단계 수는 `total`로 가변, 배지 문구는 외부 주입 |
 | SequenceItem | 좌측 순번 배지 + 점선 연결선, 우측 정보 카드로 이루어진 목록 한 줄. 순서가 있는 항목을 세로로 나열할 때 쓴다 | `shared/ui/sequence-item`. 마지막 줄은 `isLast`로 연결선을 숨긴다 |
 | 목표 자세 | 코스가 최종적으로 완성을 노리는 자세 | |

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -12,6 +12,7 @@ import { PoseChallengePage } from "@/pages/pose-challenge";
 import { ScreeningPage } from "@/pages/screening";
 import { MyPage } from "@/pages/my";
 import { CompletePage } from "@/pages/complete";
+import { MyEditPage } from "@/pages/my-edit";
 
 type AppRoute = {
   path: RoutePath;
@@ -42,6 +43,7 @@ export const APP_ROUTES: Record<"tab" | "bare", RouteGroup> = {
       { path: ROUTES.dailyRoutineExercise, element: <ExerciseDetailPage /> },
       { path: ROUTES.poseChallenge, element: <PoseChallengePage /> },
       { path: ROUTES.complete, element: <CompletePage /> },
+      { path: ROUTES.myEdit, element: <MyEditPage /> },
     ],
   },
 };

--- a/src/features/onboarding-form/components/ExperienceLevelOptions.tsx
+++ b/src/features/onboarding-form/components/ExperienceLevelOptions.tsx
@@ -1,0 +1,33 @@
+import { cn } from "@/shared/lib/cn";
+import { Button } from "@/shared/ui/button";
+import { EXPERIENCE_LEVEL_OPTIONS } from "../constants/form-fields";
+
+export type ExperienceLevel = (typeof EXPERIENCE_LEVEL_OPTIONS)[number]["value"];
+
+type ExperienceLevelOptionsProps = {
+  value?: ExperienceLevel;
+  onChange: (value: ExperienceLevel) => void;
+  className?: string;
+};
+
+export default function ExperienceLevelOptions({
+  value,
+  onChange,
+  className,
+}: ExperienceLevelOptionsProps) {
+  return (
+    <div className={cn("flex flex-col gap-[1.2rem]", className)}>
+      {EXPERIENCE_LEVEL_OPTIONS.map((option) => (
+        <Button
+          key={option.value}
+          color="secondary"
+          isSelected={value === option.value}
+          onClick={() => onChange(option.value)}
+          className="py-[2.2rem] px-[4.1rem]"
+        >
+          {option.label}
+        </Button>
+      ))}
+    </div>
+  );
+}

--- a/src/features/onboarding-form/index.ts
+++ b/src/features/onboarding-form/index.ts
@@ -1,1 +1,4 @@
 export { OnboardingForm } from "./ui/OnboardingForm";
+export { default as ExperienceLevelOptions } from "./components/ExperienceLevelOptions";
+export type { ExperienceLevel } from "./components/ExperienceLevelOptions";
+export { EXPERIENCE_LEVEL_OPTIONS } from "./constants/form-fields";

--- a/src/features/onboarding-form/steps/ExperienceLevelStep.tsx
+++ b/src/features/onboarding-form/steps/ExperienceLevelStep.tsx
@@ -1,7 +1,6 @@
-import { Button } from "@/shared/ui/button";
-import { EXPERIENCE_LEVEL_OPTIONS } from "../constants/form-fields";
 import { useOnboardingForm } from "../model/use-onboarding-form";
 import StepLayout from "../components/StepLayout";
+import ExperienceLevelOptions from "../components/ExperienceLevelOptions";
 
 export default function ExperienceLevelStep() {
   const {
@@ -11,19 +10,7 @@ export default function ExperienceLevelStep() {
 
   return (
     <StepLayout title="운동을 하신지 얼마나 됐나요?">
-      <div className="flex flex-col gap-[1.2rem]">
-        {EXPERIENCE_LEVEL_OPTIONS.map((option) => (
-          <Button
-            key={option.value}
-            color="secondary"
-            isSelected={experienceLevel === option.value}
-            onClick={() => updateExperienceLevel(option.value)}
-            className="py-[2.2rem] px-[4.1rem]"
-          >
-            {option.label}
-          </Button>
-        ))}
-      </div>
+      <ExperienceLevelOptions value={experienceLevel} onChange={updateExperienceLevel} />
     </StepLayout>
   );
 }

--- a/src/features/screening-flow/index.ts
+++ b/src/features/screening-flow/index.ts
@@ -1,1 +1,3 @@
 export { ScreeningFlow } from "./ui/ScreeningFlow";
+export { BODY_PART_MARKER_POSITION, BODY_PART_NAMES } from "./constants/body-parts";
+export type { BodyPartCode } from "./constants/body-parts";

--- a/src/pages/my-edit/index.ts
+++ b/src/pages/my-edit/index.ts
@@ -1,0 +1,1 @@
+export { MyEditPage } from "./ui/MyEditPage";

--- a/src/pages/my-edit/ui/ExperienceStep.tsx
+++ b/src/pages/my-edit/ui/ExperienceStep.tsx
@@ -1,0 +1,22 @@
+import { ExperienceLevelOptions, type ExperienceLevel } from "@/features/onboarding-form";
+import { TopNavBar } from "@/shared/ui/top-nav-bar";
+
+type ExperienceStepProps = {
+  value: ExperienceLevel;
+  onChange: (value: ExperienceLevel) => void;
+  onBack: () => void;
+};
+
+export function ExperienceStep({ value, onChange, onBack }: ExperienceStepProps) {
+  return (
+    <main className="flex min-h-screen flex-col bg-gray-98 px-6">
+      <TopNavBar onBack={onBack}>
+        <h1 className="typo-headline-emphasized text-ink-strong">운동 경력</h1>
+      </TopNavBar>
+
+      <div className="pt-9">
+        <ExperienceLevelOptions value={value} onChange={onChange} />
+      </div>
+    </main>
+  );
+}

--- a/src/pages/my-edit/ui/MyEditPage.tsx
+++ b/src/pages/my-edit/ui/MyEditPage.tsx
@@ -1,0 +1,50 @@
+import { useState } from "react";
+import { useNavigate, useSearchParams } from "react-router";
+import { type ExperienceLevel } from "@/features/onboarding-form";
+import { createStepPath, ROUTES } from "@/shared/config/routes";
+import { ExperienceStep } from "./ExperienceStep";
+import { ProfileEditForm } from "./ProfileEditForm";
+
+const editStepPath = createStepPath<"experience">(ROUTES.myEdit);
+
+export function MyEditPage() {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const isEditingExperience = searchParams.get("step") === "experience";
+
+  // TODO: 실제 유저 프로필 API 연동 전까지의 목데이터. 필드마다 나중에 실제 응답 형식이 다를 수 있어 하나의 객체로 묶지 않고 각자 하드코딩해둔다.
+  const [nickname, setNickname] = useState("한두살차이");
+  const [experienceLevel, setExperienceLevel] = useState<ExperienceLevel>("ONE_TO_THREE_YEARS");
+  const [heightCm, setHeightCm] = useState("160");
+  const [weightKg, setWeightKg] = useState("50");
+
+  const handleSave = () => {
+    // TODO: 실제 프로필 저장 API 연동
+    navigate(-1);
+  };
+
+  if (isEditingExperience) {
+    return (
+      <ExperienceStep
+        value={experienceLevel}
+        onChange={setExperienceLevel}
+        onBack={() => navigate(-1)}
+      />
+    );
+  }
+
+  return (
+    <ProfileEditForm
+      nickname={nickname}
+      onNicknameChange={setNickname}
+      experienceLevel={experienceLevel}
+      onEditExperience={() => navigate(editStepPath("experience"))}
+      heightCm={heightCm}
+      onHeightChange={setHeightCm}
+      weightKg={weightKg}
+      onWeightChange={setWeightKg}
+      onBack={() => navigate(-1)}
+      onSave={handleSave}
+    />
+  );
+}

--- a/src/pages/my-edit/ui/ProfileEditForm.tsx
+++ b/src/pages/my-edit/ui/ProfileEditForm.tsx
@@ -1,0 +1,110 @@
+import type { ReactNode } from "react";
+import { EXPERIENCE_LEVEL_OPTIONS, type ExperienceLevel } from "@/features/onboarding-form";
+import { cn } from "@/shared/lib/cn";
+import { CTAButton } from "@/shared/ui/button";
+import { NumberField } from "@/shared/ui/number-field";
+import { TextField } from "@/shared/ui/text-field";
+import { TopNavBar } from "@/shared/ui/top-nav-bar";
+
+type ProfileEditFormProps = {
+  nickname: string;
+  onNicknameChange: (value: string) => void;
+  experienceLevel: ExperienceLevel;
+  onEditExperience: () => void;
+  heightCm: string;
+  onHeightChange: (value: string) => void;
+  weightKg: string;
+  onWeightChange: (value: string) => void;
+  onBack: () => void;
+  onSave: () => void;
+};
+
+export function ProfileEditForm({
+  nickname,
+  onNicknameChange,
+  experienceLevel,
+  onEditExperience,
+  heightCm,
+  onHeightChange,
+  weightKg,
+  onWeightChange,
+  onBack,
+  onSave,
+}: ProfileEditFormProps) {
+  return (
+    <main className="flex min-h-screen flex-col bg-gray-98 px-6">
+      <TopNavBar onBack={onBack}>
+        <h1 className="typo-headline-emphasized text-ink-strong">프로필 편집</h1>
+      </TopNavBar>
+
+      <div className="flex flex-col gap-6 pt-2">
+        <Field label="닉네임" htmlFor="nickname-field">
+          <TextField id="nickname-field" value={nickname} onValueChange={onNicknameChange} />
+        </Field>
+
+        <Field label="운동 경력">
+          <button
+            type="button"
+            onClick={onEditExperience}
+            className="flex h-[8.2rem] w-full items-center justify-between rounded-[2rem] border border-border-base bg-bg-surface px-8 text-left"
+          >
+            <span className="typo-body-emphasized text-ink-strong">
+              {EXPERIENCE_LEVEL_OPTIONS.find((option) => option.value === experienceLevel)?.label}
+            </span>
+            <span className="typo-subheadline-regular text-gray-50">{"변경 >"}</span>
+          </button>
+        </Field>
+
+        <div className="flex gap-4">
+          <Field label="키" htmlFor="height-field" className="flex-1">
+            <NumberField
+              id="height-field"
+              placeholder="160"
+              suffix="cm"
+              value={heightCm}
+              onValueChange={onHeightChange}
+            />
+          </Field>
+          <Field label="몸무게" htmlFor="weight-field" className="flex-1">
+            <NumberField
+              id="weight-field"
+              placeholder="50"
+              suffix="kg"
+              value={weightKg}
+              onValueChange={onWeightChange}
+            />
+          </Field>
+        </div>
+      </div>
+
+      <CTAButton>
+        <CTAButton.Single onClick={onSave}>저장</CTAButton.Single>
+      </CTAButton>
+    </main>
+  );
+}
+
+function Field({
+  label,
+  htmlFor,
+  className,
+  children,
+}: {
+  label: string;
+  htmlFor?: string;
+  className?: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className={cn("flex flex-col gap-4", className)}>
+      {htmlFor ? (
+        <label htmlFor={htmlFor} className="typo-subheadline-regular text-gray-50">
+          {label}
+        </label>
+      ) : (
+        <span className="typo-subheadline-regular text-gray-50">{label}</span>
+      )}
+      {children}
+    </div>
+  );
+}

--- a/src/pages/my/ui/MuscleTargetCard.tsx
+++ b/src/pages/my/ui/MuscleTargetCard.tsx
@@ -1,0 +1,59 @@
+import {
+  BODY_PART_MARKER_POSITION,
+  BODY_PART_NAMES,
+  type BodyPartCode,
+} from "@/features/screening-flow";
+import { cn } from "@/shared/lib/cn";
+import { MannequinScanIcon } from "@/shared/ui/icons";
+import {
+  RADIO_BASE,
+  RADIO_INDICATOR_SELECTED_BG,
+  RADIO_INDICATOR_SHAPE,
+  RADIO_SHAPE,
+} from "@/shared/ui/radio";
+
+// TODO: 실제 근육 타겟/난이도 API 연동 전까지의 목데이터
+const MOCK_BODY_PART: BodyPartCode = "BACK";
+const MOCK_DIFFICULTY = "난이도 하";
+
+export function MuscleTargetCard() {
+  const markerPosition = BODY_PART_MARKER_POSITION[MOCK_BODY_PART];
+
+  return (
+    <div className="relative flex h-[252px] w-full overflow-hidden rounded-[24px] bg-gradient-to-b from-primary-50 from-15% to-primary-200 shadow-[inset_0_0_8px_4px_var(--color-gray-98)]">
+      <div className="flex flex-col justify-between p-6">
+        <p className="relative z-10 typo-title-3-emphasized text-gray-40">
+          <span className="text-tertiary-600">{BODY_PART_NAMES[MOCK_BODY_PART]}근육</span>을{" "}
+          <span className="text-tertiary-600">{MOCK_DIFFICULTY}</span>로
+          <br />
+          강화하고 있어요
+        </p>
+
+        {/* TODO: 난이도 설정(스크리닝) 플로우로 이동 */}
+        <button
+          type="button"
+          className="typo-body-emphasized relative z-10 w-fit rounded-[8px] bg-tertiary-700 px-4 py-3 text-primary-200"
+        >
+          난이도 조정하기
+        </button>
+      </div>
+
+      {/*
+        실루엣(MannequinScanIcon)과 마커 위치(BODY_PART_MARKER_POSITION)는 screening-flow와
+        같은 것을 재사용한다.
+        screening의 Mannequin과 동일한 좌표계를 공유한다.
+      */}
+      <div aria-hidden="true" className="relative flex-1">
+        <div className="pointer-events-none absolute top-[13px] left-1/2 h-[442px] -translate-x-1/2">
+          <MannequinScanIcon className="h-full w-auto" />
+          <div
+            style={markerPosition}
+            className={cn(RADIO_BASE, RADIO_SHAPE, "absolute -translate-x-1/2 -translate-y-1/2")}
+          >
+            <div className={cn(RADIO_INDICATOR_SHAPE, RADIO_INDICATOR_SELECTED_BG)} />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/my/ui/MyPage.tsx
+++ b/src/pages/my/ui/MyPage.tsx
@@ -1,7 +1,60 @@
+import { Link } from "react-router";
+import { ROUTES } from "@/shared/config/routes";
+import { BackArrowIcon } from "@/shared/ui/icons";
+import { MuscleTargetCard } from "./MuscleTargetCard";
+
+// TODO: 실제 유저 프로필 API 연동 전까지의 목데이터
+const MOCK_NICKNAME = "한두살차이";
+
 export function MyPage() {
   return (
-    <main className="flex min-h-screen items-center justify-center">
-      <h1 className="text-2xl font-semibold">MY</h1>
+    <main className="flex min-h-screen flex-col bg-gray-97">
+      <div className="flex flex-1 flex-col gap-[36px] px-6 pt-5">
+        <div className="flex flex-col gap-7">
+          <h1 className="typo-title-1-emphasized text-ink-base">마이</h1>
+
+          <div className="flex flex-col gap-5">
+            <Link
+              to={ROUTES.myEdit}
+              className="flex items-center gap-[14px] rounded-[18px] bg-gray-99 px-6 py-5"
+            >
+              <span className="flex-1 typo-headline-emphasized text-[#4a4a4a]">
+                {MOCK_NICKNAME}님
+              </span>
+              <span className="typo-caption-1-regular text-ink-muted">편집 ›</span>
+            </Link>
+
+            <MuscleTargetCard />
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-2">
+          {/* TODO: 확인 모달 및 로그아웃 처리 */}
+          <MyMenuRow label="로그아웃" />
+          {/* TODO: 확인 모달 및 회원탈퇴 처리 */}
+          <MyMenuRow label="회원탈퇴" />
+        </div>
+      </div>
+
+      <footer className="flex items-center gap-3 bg-gray-95 px-6 pt-6 pb-[130px] typo-caption-2-emphasized text-gray-60">
+        {/* TODO: 개인정보 처리방침 웹뷰 연결 */}
+        <button type="button">개인정보 처리방침</button>
+        <span aria-hidden="true" className="size-2 rounded-full bg-gray-60" />
+        {/* TODO: 서비스 이용약관 웹뷰 연결 */}
+        <button type="button">서비스 이용약관</button>
+      </footer>
     </main>
+  );
+}
+
+function MyMenuRow({ label }: { label: string }) {
+  return (
+    <button
+      type="button"
+      className="flex items-center justify-between py-4 text-left typo-body-regular text-ink-base"
+    >
+      {label}
+      <BackArrowIcon className="size-7 -scale-x-100 text-ink-base" />
+    </button>
   );
 }

--- a/src/shared/config/routes.ts
+++ b/src/shared/config/routes.ts
@@ -9,6 +9,7 @@ export const ROUTES = {
   login: "/login",
   my: "my",
   complete: "complete/:sessionId",
+  myEdit: "/my/edit",
 } as const;
 
 export type RoutePath = (typeof ROUTES)[keyof typeof ROUTES];

--- a/src/shared/ui/radio/index.ts
+++ b/src/shared/ui/radio/index.ts
@@ -1,1 +1,8 @@
 export { default as Radio } from "./Radio";
+export {
+  RADIO_BASE,
+  RADIO_SHAPE,
+  RADIO_INDICATOR_SHAPE,
+  RADIO_INDICATOR_SELECTED_BG,
+  RADIO_INDICATOR_UNSELECTED_BG,
+} from "./theme";

--- a/src/shared/ui/text-field/TextField.tsx
+++ b/src/shared/ui/text-field/TextField.tsx
@@ -1,0 +1,44 @@
+import { useState, type ChangeEvent, type ComponentProps } from "react";
+import { cn } from "@/shared/lib/cn";
+
+export interface TextFieldProps extends Omit<
+  ComponentProps<"input">,
+  "type" | "value" | "defaultValue" | "onChange" | "children"
+> {
+  value?: string;
+  defaultValue?: string;
+  onValueChange?: (value: string) => void;
+  error?: boolean;
+}
+
+export default function TextField({
+  error = false,
+  className,
+  value,
+  defaultValue,
+  onValueChange,
+  ...props
+}: TextFieldProps) {
+  const [uncontrolledValue, setUncontrolledValue] = useState(defaultValue ?? "");
+  const isControlled = value !== undefined;
+  const currentValue = isControlled ? value : uncontrolledValue;
+
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    if (!isControlled) setUncontrolledValue(e.target.value);
+    onValueChange?.(e.target.value);
+  };
+
+  return (
+    <input
+      type="text"
+      value={currentValue}
+      onChange={handleChange}
+      className={cn(
+        "h-[8.2rem] w-full rounded-[2rem] border bg-bg-surface px-8 typo-body-emphasized text-ink-strong outline-none placeholder:text-gray-95",
+        error ? "border-error" : "border-border-base focus:border-accent-base",
+        className,
+      )}
+      {...props}
+    />
+  );
+}

--- a/src/shared/ui/text-field/index.ts
+++ b/src/shared/ui/text-field/index.ts
@@ -1,0 +1,2 @@
+export { default as TextField } from "./TextField";
+export type { TextFieldProps } from "./TextField";


### PR DESCRIPTION
## Summary

Figma 디자인 기반으로 마이페이지(`/my`)와 프로필 편집(`/my/edit`) 화면을 구현했다. 목데이터 기반 UI까지만 다루고, API 연동과 입력값 검증은 다음 작업으로 미룬다.

## Related Issues

- close #55

## PR Point (To Reviewer)

- **"운동 경력 변경"은 이슈 원문(TODO no-op)과 다르게 실제로 동작함.** 작업 중 요청으로 범위가 바뀌었다 — `onboarding-form`에서 옵션 선택 UI(`ExperienceLevelOptions`)를 컨텍스트 독립적으로 뽑아 재사용하고, 같은 `/my/edit` 라우트에서 `?step=experience` 쿼리로 화면을 전환한다(온보딩의 `?step=` 패턴과 동일, `createStepPath` 재사용).
- **"난이도 조정하기"는 이슈대로 TODO no-op 유지.** 겉보기엔 screening의 부위별 난이도 변경 스텝과 이어질 것 같지만, 그쪽은 이전 스텝의 router state가 있어야 진입 가능하고 진입 시 코스 재추천까지 트리거돼서 이번 스코프의 "가볍게 바꾸고 복귀"와는 안 맞아 그대로 뒀다.
- **닉네임/키/몸무게 유효성 검증은 이번 스코프에서 제외.** 이슈 완료조건에서도 해당 항목에 취소선 처리하고 코멘트로 남겨뒀다 — 이번엔 UI만, 검증은 별도 작업으로.
- 마이페이지의 근육 타겟 카드는 실루엣/마커 둘 다 새 에셋을 안 만들고 `screening-flow`의 `MannequinScanIcon`/`BODY_PART_MARKER_POSITION`을 재사용했다(마커는 `Radio`의 시각 토큰만 가져다 `<div>`로 구성 — 클릭될 일 없는 장식 요소라 `<button>` 시맨틱은 피함).

## Screenshot

| 화면 | 경로 |
|---------|--------|
| 마이페이지 | <img width="300" alt="localhost_5173_my(iPhone 12 Pro)" src="https://github.com/user-attachments/assets/a7f108a6-286e-4646-a05f-2f94d8e93adf" /> |
| 프로필 편집 | <img width="300" alt="localhost_5173_my(iPhone 12 Pro) (1)" src="https://github.com/user-attachments/assets/128d35a9-f368-492b-8491-7709444874dd" /> |
| 운동 경력 선택 | <img width="300" alt="localhost_5173_my(iPhone 12 Pro) (2)" src="https://github.com/user-attachments/assets/6e32a1cd-a0da-428b-a5c9-5e9f95122f9f" /> |

## ETC

없음