### PR TITLE
feat: 마이페이지/프로필 편집 회원 프로필 API 연동

### DIFF
--- a/src/entities/member/index.ts
+++ b/src/entities/member/index.ts
@@ -1,3 +1,4 @@
 export type { Member } from "./model/member";
 export { useMemberProfile } from "./model/use-member-profile";
 export { useUpdateMemberProfile } from "./model/use-update-member-profile";
+export { useWithdrawMember } from "./model/use-withdraw-member";

--- a/src/entities/member/model/use-withdraw-member.ts
+++ b/src/entities/member/model/use-withdraw-member.ts
@@ -1,0 +1,10 @@
+import { useMutation } from "@tanstack/react-query";
+import { membersApi } from "@/shared/api";
+
+export function useWithdrawMember() {
+  return useMutation<void, unknown, void>({
+    mutationFn: async () => {
+      await membersApi.withdraw();
+    },
+  });
+}

--- a/src/features/onboarding-form/index.ts
+++ b/src/features/onboarding-form/index.ts
@@ -1,4 +1,8 @@
 export { OnboardingForm } from "./ui/OnboardingForm";
 export { default as ExperienceLevelOptions } from "./components/ExperienceLevelOptions";
 export type { ExperienceLevel } from "./components/ExperienceLevelOptions";
-export { EXPERIENCE_LEVEL_OPTIONS } from "./constants/form-fields";
+export {
+  EXPERIENCE_LEVEL_OPTIONS,
+  EXPERIENCE_LEVELS,
+  MIN_MAX_FIELDS,
+} from "./constants/form-fields";

--- a/src/pages/my-edit/model/schema.ts
+++ b/src/pages/my-edit/model/schema.ts
@@ -1,0 +1,47 @@
+import { z } from "zod";
+// TODO: pages/my-edit는 features/profile-edit로 옮기는 게 맞아 보이지만, 그러면 이 import가 features 간 직접 참조가 된다(레포 규칙 위반). EXPERIENCE_LEVELS/MIN_MAX_FIELDS를 entities/member로 옮기고 나서 진행할 것 — 지금은 onboarding-form이 다른 작업 중이라 보류.
+import { EXPERIENCE_LEVELS, MIN_MAX_FIELDS } from "@/features/onboarding-form";
+
+const NICKNAME_MIN = 2;
+const NICKNAME_MAX = 12;
+const NICKNAME_PATTERN = /^[가-힣a-zA-Z0-9 ]*$/;
+
+// 온보딩(MIN_MAX_FIELDS.heightCm.max = 270)은 실제 API(INVALID_HEIGHT, 100~250cm)와 어긋나 있다.
+// 온보딩 쪽 수정은 이 작업 범위 밖이라, 키 상한만 실제 API 기준으로 보정해서 쓴다.
+const HEIGHT_MAX_CM = 250;
+
+export const ERROR_MESSAGES = {
+  nickname: {
+    min: `닉네임은 ${NICKNAME_MIN}자 이상이어야 해요`,
+    max: `닉네임은 ${NICKNAME_MAX}자 이하여야 해요`,
+    pattern: "닉네임에 특수문자는 쓸 수 없어요",
+  },
+  heightCm: {
+    min: `키는 ${MIN_MAX_FIELDS.heightCm.min}cm 이상이어야 해요`,
+    max: `키는 ${HEIGHT_MAX_CM}cm 이하여야 해요`,
+  },
+  weightKg: {
+    min: `몸무게는 ${MIN_MAX_FIELDS.weightKg.min}kg 이상이어야 해요`,
+    max: `몸무게는 ${MIN_MAX_FIELDS.weightKg.max}kg 이하여야 해요`,
+  },
+};
+
+// TODO: 온보딩(features/onboarding-form/model/schema.ts)은 heightCm/weightKg를 z.number()로 검증하고, 여기는 NumberField가 string 값을 주고받아서 string 기반 .refine()으로 따로 짰다 — 지금은 MIN_MAX_FIELDS 숫자만 재사용하고 검증 로직 자체는 중복이다. 온보딩 쪽을 다음에 손볼 때 z.coerce.number() 등으로 맞춰서 검증 로직(과 키 상한 270 버그)까지 완전히 공유하는 걸 검토할 것.
+export const profileEditSchema = z.object({
+  nickname: z
+    .string()
+    .min(NICKNAME_MIN, ERROR_MESSAGES.nickname.min)
+    .max(NICKNAME_MAX, ERROR_MESSAGES.nickname.max)
+    .regex(NICKNAME_PATTERN, ERROR_MESSAGES.nickname.pattern),
+  experienceLevel: z.enum(EXPERIENCE_LEVELS),
+  heightCm: z
+    .string()
+    .refine((value) => Number(value) >= MIN_MAX_FIELDS.heightCm.min, ERROR_MESSAGES.heightCm.min)
+    .refine((value) => Number(value) <= HEIGHT_MAX_CM, ERROR_MESSAGES.heightCm.max),
+  weightKg: z
+    .string()
+    .refine((value) => Number(value) >= MIN_MAX_FIELDS.weightKg.min, ERROR_MESSAGES.weightKg.min)
+    .refine((value) => Number(value) <= MIN_MAX_FIELDS.weightKg.max, ERROR_MESSAGES.weightKg.max),
+});
+
+export type ProfileEditFormValues = z.infer<typeof profileEditSchema>;

--- a/src/pages/my-edit/model/to-form-values.ts
+++ b/src/pages/my-edit/model/to-form-values.ts
@@ -1,0 +1,11 @@
+import type { Member } from "@/entities/member";
+import type { ProfileEditFormValues } from "./schema";
+
+export function toProfileEditFormValues(member: Member): ProfileEditFormValues {
+  return {
+    nickname: member.nickname ?? "",
+    experienceLevel: member.experienceLevel ?? "UNDER_ONE_YEAR",
+    heightCm: member.heightCm != null ? String(member.heightCm) : "",
+    weightKg: member.weightKg != null ? String(member.weightKg) : "",
+  };
+}

--- a/src/pages/my-edit/model/use-profile-edit-form.ts
+++ b/src/pages/my-edit/model/use-profile-edit-form.ts
@@ -1,0 +1,65 @@
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm, useWatch } from "react-hook-form";
+import type { Member } from "@/entities/member";
+import type { ExperienceLevel } from "@/features/onboarding-form";
+import { profileEditSchema, type ProfileEditFormValues } from "./schema";
+import { toProfileEditFormValues } from "./to-form-values";
+
+const WATCHED_FIELDS = ["nickname", "experienceLevel", "heightCm", "weightKg"] as const;
+
+export function useProfileEditForm(member: Member) {
+  const {
+    control,
+    setValue,
+    trigger,
+    handleSubmit,
+    reset,
+    formState: { errors, isDirty, isValid },
+  } = useForm<ProfileEditFormValues>({
+    resolver: zodResolver(profileEditSchema),
+    defaultValues: toProfileEditFormValues(member),
+    mode: "onBlur",
+  });
+
+  const [nickname, experienceLevel, heightCm, weightKg] = useWatch({
+    control,
+    name: WATCHED_FIELDS,
+  });
+
+  // blur로 한 번 에러가 뜬 뒤에는 고칠 때마다 바로 재검증해서 에러가 즉시 사라지게 한다
+  const updateNickname = (value: string) =>
+    setValue("nickname", value, { shouldDirty: true, shouldValidate: Boolean(errors.nickname) });
+
+  const updateExperienceLevel = (value: ExperienceLevel) =>
+    setValue("experienceLevel", value, { shouldDirty: true });
+
+  const updateHeight = (value: string) =>
+    setValue("heightCm", value, { shouldDirty: true, shouldValidate: Boolean(errors.heightCm) });
+
+  const updateWeight = (value: string) =>
+    setValue("weightKg", value, { shouldDirty: true, shouldValidate: Boolean(errors.weightKg) });
+
+  const validateNickname = () => trigger("nickname");
+  const validateHeight = () => trigger("heightCm");
+  const validateWeight = () => trigger("weightKg");
+
+  // 저장 성공 직후 서버가 돌려준 값으로 dirty 기준선을 다시 잡는다 — 그래야 저장 버튼이 다시 disabled로 돌아온다
+  const resetToMember = (updated: Member) => reset(toProfileEditFormValues(updated));
+
+  return {
+    values: { nickname, experienceLevel, heightCm, weightKg },
+    errors: {
+      nickname: errors.nickname?.message,
+      heightCm: errors.heightCm?.message,
+      weightKg: errors.weightKg?.message,
+    },
+    handlers: { updateNickname, updateExperienceLevel, updateHeight, updateWeight },
+    validateNickname,
+    validateHeight,
+    validateWeight,
+    isDirty,
+    isValid,
+    handleSubmit,
+    resetToMember,
+  };
+}

--- a/src/pages/my-edit/ui/ExperienceStep.tsx
+++ b/src/pages/my-edit/ui/ExperienceStep.tsx
@@ -9,7 +9,7 @@ type ExperienceStepProps = {
 
 export function ExperienceStep({ value, onChange, onBack }: ExperienceStepProps) {
   return (
-    <main className="flex min-h-screen flex-col bg-gray-98 px-6">
+    <>
       <TopNavBar onBack={onBack}>
         <h1 className="typo-headline-emphasized text-ink-strong">운동 경력</h1>
       </TopNavBar>
@@ -17,6 +17,6 @@ export function ExperienceStep({ value, onChange, onBack }: ExperienceStepProps)
       <div className="pt-9">
         <ExperienceLevelOptions value={value} onChange={onChange} />
       </div>
-    </main>
+    </>
   );
 }

--- a/src/pages/my-edit/ui/MyEditPage.tsx
+++ b/src/pages/my-edit/ui/MyEditPage.tsx
@@ -1,7 +1,7 @@
-import { useState } from "react";
 import { useNavigate, useSearchParams } from "react-router";
-import { type ExperienceLevel } from "@/features/onboarding-form";
+import { type Member, useMemberProfile, useUpdateMemberProfile } from "@/entities/member";
 import { createStepPath, ROUTES } from "@/shared/config/routes";
+import { useProfileEditForm } from "../model/use-profile-edit-form";
 import { ExperienceStep } from "./ExperienceStep";
 import { ProfileEditForm } from "./ProfileEditForm";
 
@@ -11,40 +11,96 @@ export function MyEditPage() {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const isEditingExperience = searchParams.get("step") === "experience";
+  const { data: member, isPending, error } = useMemberProfile();
 
-  // TODO: 실제 유저 프로필 API 연동 전까지의 목데이터. 필드마다 나중에 실제 응답 형식이 다를 수 있어 하나의 객체로 묶지 않고 각자 하드코딩해둔다.
-  const [nickname, setNickname] = useState("한두살차이");
-  const [experienceLevel, setExperienceLevel] = useState<ExperienceLevel>("ONE_TO_THREE_YEARS");
-  const [heightCm, setHeightCm] = useState("160");
-  const [weightKg, setWeightKg] = useState("50");
+  return (
+    <main className="flex min-h-screen flex-col bg-gray-98 px-6">
+      {isPending ? null : error || !member ? (
+        // TODO: 에러 상태 통일
+        <div className="flex flex-1 flex-col items-center justify-center">
+          <p className="typo-body-regular text-gray-50">
+            정보를 불러오지 못했어요. 잠시 후 다시 시도해 주세요.
+          </p>
+        </div>
+      ) : (
+        <MyEditForm
+          member={member}
+          isEditingExperience={isEditingExperience}
+          onNavigateBack={() => navigate(-1)}
+          onEditExperience={() => navigate(editStepPath("experience"))}
+        />
+      )}
+    </main>
+  );
+}
 
-  const handleSave = () => {
-    // TODO: 실제 프로필 저장 API 연동
-    navigate(-1);
-  };
+function MyEditForm({
+  member,
+  isEditingExperience,
+  onNavigateBack,
+  onEditExperience,
+}: {
+  member: Member;
+  isEditingExperience: boolean;
+  onNavigateBack: () => void;
+  onEditExperience: () => void;
+}) {
+  const {
+    values,
+    errors,
+    handlers,
+    validateNickname,
+    validateHeight,
+    validateWeight,
+    isDirty,
+    isValid,
+    handleSubmit,
+    resetToMember,
+  } = useProfileEditForm(member);
+  const updateMemberProfile = useUpdateMemberProfile();
+
+  const handleSave = handleSubmit((data) => {
+    updateMemberProfile.mutate(
+      {
+        nickname: data.nickname,
+        experienceLevel: data.experienceLevel,
+        heightCm: Number(data.heightCm),
+        weightKg: Number(data.weightKg),
+      },
+      { onSuccess: resetToMember },
+    );
+  });
 
   if (isEditingExperience) {
     return (
       <ExperienceStep
-        value={experienceLevel}
-        onChange={setExperienceLevel}
-        onBack={() => navigate(-1)}
+        value={values.experienceLevel}
+        onChange={handlers.updateExperienceLevel}
+        onBack={onNavigateBack}
       />
     );
   }
 
   return (
     <ProfileEditForm
-      nickname={nickname}
-      onNicknameChange={setNickname}
-      experienceLevel={experienceLevel}
-      onEditExperience={() => navigate(editStepPath("experience"))}
-      heightCm={heightCm}
-      onHeightChange={setHeightCm}
-      weightKg={weightKg}
-      onWeightChange={setWeightKg}
-      onBack={() => navigate(-1)}
+      nickname={values.nickname}
+      onNicknameChange={handlers.updateNickname}
+      onNicknameBlur={validateNickname}
+      nicknameError={errors.nickname}
+      experienceLevel={values.experienceLevel}
+      onEditExperience={onEditExperience}
+      heightCm={values.heightCm}
+      onHeightChange={handlers.updateHeight}
+      onHeightBlur={validateHeight}
+      heightError={errors.heightCm}
+      weightKg={values.weightKg}
+      onWeightChange={handlers.updateWeight}
+      onWeightBlur={validateWeight}
+      weightError={errors.weightKg}
+      onBack={onNavigateBack}
       onSave={handleSave}
+      isSaving={updateMemberProfile.isPending}
+      canSave={isDirty && isValid}
     />
   );
 }

--- a/src/pages/my-edit/ui/ProfileEditForm.tsx
+++ b/src/pages/my-edit/ui/ProfileEditForm.tsx
@@ -9,37 +9,64 @@ import { TopNavBar } from "@/shared/ui/top-nav-bar";
 type ProfileEditFormProps = {
   nickname: string;
   onNicknameChange: (value: string) => void;
+  onNicknameBlur?: () => void;
+  nicknameError?: string;
   experienceLevel: ExperienceLevel;
   onEditExperience: () => void;
   heightCm: string;
   onHeightChange: (value: string) => void;
+  onHeightBlur?: () => void;
+  heightError?: string;
   weightKg: string;
   onWeightChange: (value: string) => void;
+  onWeightBlur?: () => void;
+  weightError?: string;
   onBack: () => void;
   onSave: () => void;
+  isSaving?: boolean;
+  canSave: boolean;
 };
 
 export function ProfileEditForm({
   nickname,
   onNicknameChange,
+  onNicknameBlur,
+  nicknameError,
   experienceLevel,
   onEditExperience,
   heightCm,
   onHeightChange,
+  onHeightBlur,
+  heightError,
   weightKg,
   onWeightChange,
+  onWeightBlur,
+  weightError,
   onBack,
   onSave,
+  isSaving = false,
+  canSave,
 }: ProfileEditFormProps) {
   return (
-    <main className="flex min-h-screen flex-col bg-gray-98 px-6">
+    <>
       <TopNavBar onBack={onBack}>
         <h1 className="typo-headline-emphasized text-ink-strong">프로필 편집</h1>
       </TopNavBar>
 
       <div className="flex flex-col gap-6 pt-2">
         <Field label="닉네임" htmlFor="nickname-field">
-          <TextField id="nickname-field" value={nickname} onValueChange={onNicknameChange} />
+          <div className="flex flex-col gap-2">
+            <TextField
+              id="nickname-field"
+              value={nickname}
+              onValueChange={onNicknameChange}
+              onBlur={onNicknameBlur}
+              error={Boolean(nicknameError)}
+            />
+            {nicknameError && (
+              <p className="typo-caption-1-emphasized text-ink-error">{nicknameError}</p>
+            )}
+          </div>
         </Field>
 
         <Field label="운동 경력">
@@ -57,30 +84,46 @@ export function ProfileEditForm({
 
         <div className="flex gap-4">
           <Field label="키" htmlFor="height-field" className="flex-1">
-            <NumberField
-              id="height-field"
-              placeholder="160"
-              suffix="cm"
-              value={heightCm}
-              onValueChange={onHeightChange}
-            />
+            <div className="flex flex-col gap-2">
+              <NumberField
+                id="height-field"
+                placeholder="160"
+                suffix="cm"
+                value={heightCm}
+                onValueChange={onHeightChange}
+                onBlur={onHeightBlur}
+                error={Boolean(heightError)}
+              />
+              {heightError && (
+                <p className="typo-caption-1-emphasized text-ink-error">{heightError}</p>
+              )}
+            </div>
           </Field>
           <Field label="몸무게" htmlFor="weight-field" className="flex-1">
-            <NumberField
-              id="weight-field"
-              placeholder="50"
-              suffix="kg"
-              value={weightKg}
-              onValueChange={onWeightChange}
-            />
+            <div className="flex flex-col gap-2">
+              <NumberField
+                id="weight-field"
+                placeholder="50"
+                suffix="kg"
+                value={weightKg}
+                onValueChange={onWeightChange}
+                onBlur={onWeightBlur}
+                error={Boolean(weightError)}
+              />
+              {weightError && (
+                <p className="typo-caption-1-emphasized text-ink-error">{weightError}</p>
+              )}
+            </div>
           </Field>
         </div>
       </div>
 
       <CTAButton>
-        <CTAButton.Single onClick={onSave}>저장</CTAButton.Single>
+        <CTAButton.Single onClick={onSave} disabled={isSaving || !canSave} isLoading={isSaving}>
+          저장
+        </CTAButton.Single>
       </CTAButton>
-    </main>
+    </>
   );
 }
 

--- a/src/pages/my/ui/MuscleTargetCard.tsx
+++ b/src/pages/my/ui/MuscleTargetCard.tsx
@@ -1,11 +1,9 @@
-import { useNavigate } from "react-router";
 import { useMemberProfile } from "@/entities/member";
 // TODO: 이 컴포넌트는 pages/my-edit처럼 features로 옮기는 게 맞아 보이지만, features/screening-flow를  직접 참조하고 있어 features 간 참조가 된다(레포 규칙 위반). BODY_PART_MARKER_POSITION/BODY_PART_NAMES/LEVEL_OPTIONS는 도메인 상수라 entities(예: entities/pose)로 옮기면 되지만, screeningStepPath는 screening-flow 자체의 라우팅 로직이라 entities로 옮기기 애매하다 — features로 승격할 때 같이 정리할 것.
 import {
   BODY_PART_MARKER_POSITION,
   BODY_PART_NAMES,
   LEVEL_OPTIONS,
-  screeningStepPath,
 } from "@/features/screening-flow";
 import { cn } from "@/shared/lib/cn";
 import { MannequinScanIcon } from "@/shared/ui/icons";
@@ -17,32 +15,16 @@ import {
 } from "@/shared/ui/radio";
 
 export function MuscleTargetCard() {
-  const navigate = useNavigate();
   const { data: member } = useMemberProfile();
   const bodyPartCode = member?.reinforcementBodyPartCode;
   const difficultyLabel = LEVEL_OPTIONS.find(
     (option) => option.level === member?.reinforcementLevel,
   )?.label;
 
-  const goToScreening = () => navigate(screeningStepPath("analyzing"));
-
+  // TODO: 강화 부위/난이도 미선택 상태 UI("아직 강화 부위를 선택하지 않았어요" + 스크리닝 이동)를
+  // 다시 붙일 것. 기존 동작이 의도와 안 맞아 일단 빼놨다 — 올바른 동작 정하고 재구현할 것.
   if (!bodyPartCode || !difficultyLabel) {
-    return (
-      <div className="relative flex h-[252px] w-full flex-col justify-between overflow-hidden rounded-[24px] bg-gradient-to-b from-primary-50 from-15% to-primary-200 p-6 shadow-[inset_0_0_8px_4px_var(--color-gray-98)]">
-        <p className="typo-title-3-emphasized text-gray-40">
-          아직 강화 부위를
-          <br />
-          선택하지 않았어요
-        </p>
-        <button
-          type="button"
-          onClick={goToScreening}
-          className="typo-body-emphasized w-fit rounded-[8px] bg-tertiary-700 px-4 py-3 text-primary-200"
-        >
-          부위 선택하기
-        </button>
-      </div>
-    );
+    return null;
   }
 
   const markerPosition = BODY_PART_MARKER_POSITION[bodyPartCode];
@@ -57,9 +39,9 @@ export function MuscleTargetCard() {
           강화하고 있어요
         </p>
 
+        {/* TODO: 클릭 동작 없음 — 난이도 조정(스크리닝) 플로우로 이동하는 동작을 다시 붙일 것 */}
         <button
           type="button"
-          onClick={goToScreening}
           className="typo-body-emphasized relative z-10 w-fit rounded-[8px] bg-tertiary-700 px-4 py-3 text-primary-200"
         >
           난이도 조정하기

--- a/src/pages/my/ui/MuscleTargetCard.tsx
+++ b/src/pages/my/ui/MuscleTargetCard.tsx
@@ -1,5 +1,6 @@
 import { useNavigate } from "react-router";
 import { useMemberProfile } from "@/entities/member";
+// TODO: 이 컴포넌트는 pages/my-edit처럼 features로 옮기는 게 맞아 보이지만, features/screening-flow를  직접 참조하고 있어 features 간 참조가 된다(레포 규칙 위반). BODY_PART_MARKER_POSITION/BODY_PART_NAMES/LEVEL_OPTIONS는 도메인 상수라 entities(예: entities/pose)로 옮기면 되지만, screeningStepPath는 screening-flow 자체의 라우팅 로직이라 entities로 옮기기 애매하다 — features로 승격할 때 같이 정리할 것.
 import {
   BODY_PART_MARKER_POSITION,
   BODY_PART_NAMES,

--- a/src/pages/my/ui/MyPage.tsx
+++ b/src/pages/my/ui/MyPage.tsx
@@ -1,12 +1,33 @@
-import { Link } from "react-router";
+import { Link, useNavigate } from "react-router";
+import { useMemberProfile, useWithdrawMember } from "@/entities/member";
+import { setAccessToken } from "@/shared/api";
 import { ROUTES } from "@/shared/config/routes";
 import { BackArrowIcon } from "@/shared/ui/icons";
 import { MuscleTargetCard } from "./MuscleTargetCard";
 
-// TODO: 실제 유저 프로필 API 연동 전까지의 목데이터
-const MOCK_NICKNAME = "한두살차이";
-
 export function MyPage() {
+  const navigate = useNavigate();
+  const { data: member } = useMemberProfile();
+  const withdrawMember = useWithdrawMember();
+
+  // TODO: window.confirm 대신 shared/ui 확인 모달 컴포넌트로 교체
+  const handleLogout = () => {
+    if (!window.confirm("로그아웃 하시겠습니까?")) return;
+    setAccessToken(null);
+    navigate(ROUTES.login);
+  };
+
+  // TODO: window.confirm 대신 shared/ui 확인 모달 컴포넌트로 교체
+  const handleWithdraw = () => {
+    if (!window.confirm("회원탈퇴 하시겠습니까?")) return;
+    withdrawMember.mutate(undefined, {
+      onSuccess: () => {
+        setAccessToken(null);
+        navigate(ROUTES.login);
+      },
+    });
+  };
+
   return (
     <main className="flex min-h-screen flex-col bg-gray-97">
       <div className="flex flex-1 flex-col gap-[36px] px-6 pt-5">
@@ -19,7 +40,7 @@ export function MyPage() {
               className="flex items-center gap-[14px] rounded-[18px] bg-gray-99 px-6 py-5"
             >
               <span className="flex-1 typo-headline-emphasized text-[#4a4a4a]">
-                {MOCK_NICKNAME}님
+                {member?.nickname ? `${member.nickname}님` : ""}
               </span>
               <span className="typo-caption-1-regular text-ink-muted">편집 ›</span>
             </Link>
@@ -29,10 +50,12 @@ export function MyPage() {
         </div>
 
         <div className="flex flex-col gap-2">
-          {/* TODO: 확인 모달 및 로그아웃 처리 */}
-          <MyMenuRow label="로그아웃" />
-          {/* TODO: 확인 모달 및 회원탈퇴 처리 */}
-          <MyMenuRow label="회원탈퇴" />
+          <MyMenuRow label="로그아웃" onClick={handleLogout} />
+          <MyMenuRow
+            label="회원탈퇴"
+            onClick={handleWithdraw}
+            disabled={withdrawMember.isPending}
+          />
         </div>
       </div>
 
@@ -47,11 +70,21 @@ export function MyPage() {
   );
 }
 
-function MyMenuRow({ label }: { label: string }) {
+function MyMenuRow({
+  label,
+  onClick,
+  disabled,
+}: {
+  label: string;
+  onClick: () => void;
+  disabled?: boolean;
+}) {
   return (
     <button
       type="button"
-      className="flex items-center justify-between py-4 text-left typo-body-regular text-ink-base"
+      onClick={onClick}
+      disabled={disabled}
+      className="flex items-center justify-between py-4 text-left typo-body-regular text-ink-base disabled:opacity-40"
     >
       {label}
       <BackArrowIcon className="size-7 -scale-x-100 text-ink-base" />


### PR DESCRIPTION
## Summary

`GET/PATCH/DELETE /members/me`로 마이페이지·프로필 편집 화면을 실제 API에 연동한다. 닉네임/운동경력/키/몸무게 조회·저장, 입력값 유효성 검증(react-hook-form + zod), 로그아웃/회원탈퇴를 추가한다.

## Related Issues

- close #60

## PR Point (To Reviewer)

- **확인 모달**: 이슈엔 `shared/ui` 공용 확인 모달 컴포넌트 신설이 있었지만, 급한 QA 일정 때문에 우선 `window.confirm()`으로 임시 처리했다. 각 핸들러 위에 교체용 TODO를 남겨뒀다.
- **MuscleTargetCard**: "부위 선택하기"/"난이도 조정하기" 클릭 시 스크리닝 플로우로 이동하는 동작이 있었는데, 의도한 동작이 아닌 것 같아 일단 제거하고 TODO로 남겼다. 올바른 동작을 정하고 후속 작업에서 재구현이 필요하다.
- **키/몸무게 검증값**: 온보딩(`features/onboarding-form`)의 `MIN_MAX_FIELDS`에서 숫자만 재사용했다. 몸무게(20~300kg)는 실제 API와 일치하지만, 온보딩의 키 상한(270cm)은 실제 API(100~250cm, `INVALID_HEIGHT`)와 달라서 프로필 편집 쪽에서만 250으로 보정했다 — 온보딩 자체의 270cm 버그는 이번 PR 범위 밖이라 손대지 않았다.
- **후속으로 미룬 것**: PATCH/DELETE 실패 시 사용자 피드백(`onError`) 없음, `ProfileEditFormProps`가 14개 prop으로 평탄화되어 있는 부분(Data Clumps) — 둘 다 인지하고 있고 다음 작업으로 미뤘다.
- **레이어 구조**: `pages/my-edit`, `pages/my`의 `MuscleTargetCard`는 로직상 `features`로 승격하는 게 맞아 보이지만, 둘 다 `features/onboarding-form`·`features/screening-flow`를 직접 참조하고 있어 승격 시 features 간 참조 규칙에 걸린다. 관련 상수를 `entities`로 옮긴 뒤 진행하는 게 좋아 보여 각 파일에 TODO로 남겼다.

## Screenshot

해당 없음 (구현 중 Playwright로 시각 확인은 했으나 PR에 첨부하지는 않음)

## ETC

없음