### PR TITLE
feat: 코스/운동 상세 썸네일 및 핵심 동작 문구 API 연동

### DIFF
--- a/src/entities/course/index.ts
+++ b/src/entities/course/index.ts
@@ -1,4 +1,4 @@
 export type { CourseProgress, TodayWorkoutSummary, PoseTip } from "./model/types";
 export { MOCK_COURSE_PROGRESS } from "./model/mock";
 export { isCourseCompleted, normalizePoseName } from "./model/lib";
-export { getPoseImageSrc, FALLBACK_POSE_IMAGE } from "./model/pose-images";
+export { getPoseImageSrc, resolveThumbnailSrc, FALLBACK_POSE_IMAGE } from "./model/pose-images";

--- a/src/entities/course/model/pose-images.ts
+++ b/src/entities/course/model/pose-images.ts
@@ -28,3 +28,11 @@ export function getPoseImageSrc(imageAssetKey: string | null): string {
   if (imageAssetKey === null) return fallbackImage;
   return POSE_IMAGES[imageAssetKey] ?? fallbackImage;
 }
+
+// API가 내려주는 썸네일 URL이 있으면 그대로 쓰고, 없으면 기존 asset key 매핑으로 폴백한다.
+export function resolveThumbnailSrc(
+  thumbnailUrl: string | null | undefined,
+  imageAssetKey: string | null,
+): string {
+  return thumbnailUrl ?? getPoseImageSrc(imageAssetKey);
+}

--- a/src/pages/daily-routine/api/map-course.ts
+++ b/src/pages/daily-routine/api/map-course.ts
@@ -1,4 +1,9 @@
-import { getPoseImageSrc, isCourseCompleted, type TodayWorkoutSummary } from "@/entities/course";
+import {
+  getPoseImageSrc,
+  isCourseCompleted,
+  resolveThumbnailSrc,
+  type TodayWorkoutSummary,
+} from "@/entities/course";
 import type { CourseDetailResponse, CourseStepExerciseResponse } from "./types";
 
 export interface DailyRoutineExerciseView {
@@ -42,8 +47,7 @@ function mapExercise(exercise: CourseStepExerciseResponse): DailyRoutineExercise
     category: exercise.category ?? "-",
     setInfo: buildSetInfo(exercise),
     kcal: exercise.estimatedKcal,
-    // 운동 이미지는 target-pose/* 매핑 테이블에 없는 exercise/* 네임스페이스라 지금은 항상 폴백으로 빠진다.
-    imageSrc: getPoseImageSrc(exercise.imageAssetKey),
+    imageSrc: resolveThumbnailSrc(exercise.thumbnailUrl, exercise.imageAssetKey),
   };
 }
 

--- a/src/pages/daily-routine/api/types.ts
+++ b/src/pages/daily-routine/api/types.ts
@@ -4,6 +4,7 @@ export interface CourseStepExerciseResponse {
   exerciseId: number;
   name: string;
   imageAssetKey: string | null;
+  thumbnailUrl: string | null;
   category: string | null;
   displayOrder: number;
   durationSeconds: number | null;
@@ -24,6 +25,7 @@ export interface CourseDetailResponse {
   targetPoseId: number;
   targetPoseName: string;
   targetPoseImageAssetKey: string | null;
+  targetPoseThumbnailUrl: string | null;
   name: string;
   recommendationReason: string | null;
   completedStepCount: number;

--- a/src/pages/exercise-detail/api/map-exercise.ts
+++ b/src/pages/exercise-detail/api/map-exercise.ts
@@ -55,6 +55,7 @@ export interface ExerciseGuideGroupView {
   bodyPart: string;
   highlightedMuscles: MuscleName[];
   view: MuscleDiagramView;
+  tip: string;
 }
 
 export interface ExerciseStepView {
@@ -68,7 +69,6 @@ export interface ExerciseDetailView {
   difficulty: string;
   imageSrc: string;
   guideGroups: ExerciseGuideGroupView[];
-  tip: string;
   step: ExerciseStepView | null;
 }
 
@@ -78,14 +78,25 @@ const DEFAULT_GUIDE_GROUP: ExerciseGuideGroupView = {
   bodyPart: "전신",
   highlightedMuscles: [],
   view: "front",
+  tip: "-",
 };
+
+function buildTip(muscles: MuscleResponse[]): string {
+  const descriptions = muscles
+    .slice()
+    .sort((a, b) => a.displayOrder - b.displayOrder)
+    .map((muscle) => muscle.description)
+    .filter((description): description is string => description !== null);
+
+  return descriptions.length > 0 ? descriptions.join("\n") : "-";
+}
 
 function groupMuscles(muscles: MuscleResponse[]): ExerciseGuideGroupView[] {
   const groups = BODY_PART_ORDER.filter((code) =>
     muscles.some((muscle) => muscle.bodyPartCode === code),
   ).map((code) => {
-    const highlightedMuscles = muscles
-      .filter((muscle) => muscle.bodyPartCode === code)
+    const musclesInPart = muscles.filter((muscle) => muscle.bodyPartCode === code);
+    const highlightedMuscles = musclesInPart
       .map((muscle) => toMuscleName(muscle))
       .filter((name): name is MuscleName => name !== null);
 
@@ -93,6 +104,7 @@ function groupMuscles(muscles: MuscleResponse[]): ExerciseGuideGroupView[] {
       bodyPart: BODY_PART_LABELS[code],
       highlightedMuscles,
       view: resolveView(highlightedMuscles),
+      tip: buildTip(musclesInPart),
     };
   });
 
@@ -111,9 +123,6 @@ export function mapExerciseDetailResponse(response: ExerciseDetailResponse): Exe
     difficulty: response.difficulty ? DIFFICULTY_LABELS[response.difficulty] : "-",
     imageSrc: resolveThumbnailSrc(response.thumbnailUrl, response.imageAssetKey),
     guideGroups: groupMuscles(response.muscles),
-    // TODO(소정): 핵심 동작 설명은 추후 muscles[].instruction 필드로 내려줄 예정.
-    // 아직 스펙에 없어 임시로 cautionNote를 쓰고, 없으면 "-"로 표기한다.
-    tip: response.cautionNote ?? "-",
     // TODO(소정): stepOrder/totalStepCount는 아직 스웨거 스펙에 없는 임시 필드명이다.
     step: resolveStep(response),
   };

--- a/src/pages/exercise-detail/api/map-exercise.ts
+++ b/src/pages/exercise-detail/api/map-exercise.ts
@@ -1,4 +1,4 @@
-import { getPoseImageSrc } from "@/entities/course";
+import { resolveThumbnailSrc } from "@/entities/course";
 import {
   BACK_MUSCLE_NAMES,
   MUSCLE_NAMES,
@@ -109,8 +109,7 @@ export function mapExerciseDetailResponse(response: ExerciseDetailResponse): Exe
     exerciseId: response.exerciseId,
     name: response.name,
     difficulty: response.difficulty ? DIFFICULTY_LABELS[response.difficulty] : "-",
-    // 운동 이미지는 target-pose/* 매핑 테이블에 없는 exercise/* 네임스페이스라 지금은 항상 폴백으로 빠진다.
-    imageSrc: getPoseImageSrc(response.imageAssetKey),
+    imageSrc: resolveThumbnailSrc(response.thumbnailUrl, response.imageAssetKey),
     guideGroups: groupMuscles(response.muscles),
     // TODO(소정): 핵심 동작 설명은 추후 muscles[].instruction 필드로 내려줄 예정.
     // 아직 스펙에 없어 임시로 cautionNote를 쓰고, 없으면 "-"로 표기한다.

--- a/src/pages/exercise-detail/api/types.ts
+++ b/src/pages/exercise-detail/api/types.ts
@@ -11,6 +11,7 @@ export interface MuscleResponse {
   backHighlightAssetKey: string | null;
   role: MuscleRole;
   displayOrder: number;
+  description: string | null;
 }
 
 export interface VoiceCueResponse {

--- a/src/pages/exercise-detail/ui/ExerciseDetailPage.tsx
+++ b/src/pages/exercise-detail/ui/ExerciseDetailPage.tsx
@@ -59,7 +59,7 @@ export function ExerciseDetailPage() {
       </div>
 
       <div className="relative mt-[1.6rem] h-[28rem] w-full overflow-hidden rounded-[2.8rem] bg-gray-97">
-        <CroppedWorkoutImage src={imageSrc} alt={name} />
+        <CroppedWorkoutImage src={imageSrc} alt={name} imageClassName="object-cover" />
       </div>
 
       <h2 className="mt-[4.8rem] w-full typo-headline-emphasized text-black">운동 가이드</h2>

--- a/src/pages/exercise-detail/ui/ExerciseDetailPage.tsx
+++ b/src/pages/exercise-detail/ui/ExerciseDetailPage.tsx
@@ -104,7 +104,7 @@ export function ExerciseDetailPage() {
               </span>
               <div className="flex flex-col gap-[0.8rem]">
                 <p className="typo-headline-emphasized text-gray-10">핵심 동작</p>
-                <p className="typo-body-regular text-gray-30">{exercise.tip}</p>
+                <p className="typo-body-regular whitespace-pre-line text-gray-30">{guide.tip}</p>
               </div>
             </div>
           </div>

--- a/src/shared/ui/cropped-workout-image/CroppedWorkoutImage.tsx
+++ b/src/shared/ui/cropped-workout-image/CroppedWorkoutImage.tsx
@@ -4,16 +4,18 @@ export interface CroppedWorkoutImageProps {
   src: string;
   alt?: string;
   className?: string;
+  imageClassName?: string;
 }
 
 export default function CroppedWorkoutImage({
   src,
   alt = "",
   className,
+  imageClassName,
 }: CroppedWorkoutImageProps) {
   return (
     <div className={cn("absolute inset-0 overflow-hidden", className)}>
-      <img src={src} alt={alt} className="size-full object-contain" />
+      <img src={src} alt={alt} className={cn("size-full object-contain", imageClassName)} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

데일리 루틴 코스 순서 목록과 운동 상세 화면에 API가 내려주는 실제 썸네일 URL(`thumbnailUrl`)을 연동하고, 운동 상세 이미지를 카드에 꽉 채워(object-cover) 보여준다. 또한 "핵심 동작" 문구를 고정된 `cautionNote` 대신 선택된 신체 부위 탭에 해당하는 `muscles[].description`으로 표시한다.

## Related Issues

- close #65

## PR Point (To Reviewer)

- 데일리 루틴 상단 요약 카드(워크아웃 히어로) 이미지는 의도적으로 `targetPoseImageAssetKey` 매핑을 그대로 유지했습니다(썸네일 URL 미사용). 코스 순서 목록의 개별 운동 항목만 `thumbnailUrl`을 씁니다.
- `resolveThumbnailSrc(thumbnailUrl, imageAssetKey)` 헬퍼를 `entities/course`에 추가해 "썸네일 URL 우선, 없으면 asset-key 매핑 폴백" 로직을 공유합니다.
- "핵심 동작" 문구는 탭(신체 부위)별로 해당 그룹 근육들의 `description`을 `displayOrder` 순으로 join(`\n`)해서 보여주도록 바꿨습니다. 값이 없으면 "-" 표기.

## Screenshot

<!--
| 스크린샷 | 내용 |
|---------|--------|
| 제목 | 이미지 |
| 제목 | 이미지 |
-->
해당 없음

## ETC

없음