### PR TITLE
chore: SVG 파비콘 추가

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <title>ALIGNER</title>
     <script src="https://t1.kakaocdn.net/kakao_js_sdk/2.8.2/kakao.min.js" crossorigin="anonymous"></script>
   </head>

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,7 @@
+<svg width="128" height="128" viewBox="0 0 128 128" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="128" height="128" rx="36.6784" fill="#373D00"/>
+<path d="M61.4874 35.3813H51.3262V45.1541H61.4874V35.3813Z" fill="#E6FF01"/>
+<path d="M56.5909 44.1895H46.4297V93.9994H56.5909V44.1895Z" fill="#E6FF01"/>
+<path d="M77.5323 35.3809H67.3711V45.1536H77.5323V35.3809Z" fill="#E6FF01"/>
+<path d="M82.419 44.189H72.2578V93.9989H82.419V44.189Z" fill="#E6FF01"/>
+</svg>


### PR DESCRIPTION
## Summary

- `public/favicon.svg` 등록 (정사각형 심볼 마크)
- `index.html`에 `<link rel="icon" type="image/svg+xml" href="/favicon.svg" />` 추가

## Related Issues

-

## PR Point (To Reviewer)

- 최신 브라우저는 SVG 파비콘을 직접 지원해서 별도 ICO 변환 없이 SVG만 등록했습니다. Safari 구버전 등 폴백이 필요하면 추후 ICO/PNG 세트를 추가하면 됩니다.

## Screenshot

## ETC