### PR TITLE
feat: 홈/데일리루틴/모달 인터랙션 디테일 적용

### DIFF
--- a/src/app/ScrollToTop.tsx
+++ b/src/app/ScrollToTop.tsx
@@ -4,6 +4,14 @@ import { useLocation } from "react-router";
 export function ScrollToTop() {
   const { pathname } = useLocation();
 
+  // 브라우저 기본 scrollRestoration("auto")을 끄지 않으면, 뒤로가기 시 브라우저가
+  // 이전 히스토리 엔트리의 스크롤 위치를 비동기로 복원하면서 아래 window.scrollTo(0, 0)를 덮어쓴다.
+  useEffect(() => {
+    if ("scrollRestoration" in window.history) {
+      window.history.scrollRestoration = "manual";
+    }
+  }, []);
+
   useEffect(() => {
     window.scrollTo(0, 0);
   }, [pathname]);

--- a/src/pages/daily-routine/api/map-course.ts
+++ b/src/pages/daily-routine/api/map-course.ts
@@ -21,6 +21,12 @@ export interface DailyRoutineExerciseRowView {
   stepOrder: number;
   /** 이 운동이 속한 스텝의 완료 여부. 같은 스텝의 운동은 값이 모두 같다 */
   completed: boolean;
+  /**
+   * 코스 순서 목록에서 강조(활성 색상) 표시해야 하면 true.
+   * 개별 스텝의 completed 값이 아니라, completedStepCount만큼 앞에서부터 누적으로 결정된다
+   * (스텝은 순차적으로 진행된다고 가정)
+   */
+  active: boolean;
   exercise: DailyRoutineExerciseView;
 }
 
@@ -63,11 +69,12 @@ export function mapCourseDetailResponse(response: CourseDetailResponse): CourseD
           courseStepId: step.courseStepId,
           stepOrder: step.stepOrder,
           completed: step.completed,
+          active: step.stepOrder <= response.completedStepCount,
           exercise: mapExercise(exercise),
         })),
     );
 
-  const firstIncompleteIndex = exercises.findIndex((row) => !row.completed);
+  const firstIncompleteIndex = exercises.findIndex((row) => !row.active);
   const activeIndex =
     firstIncompleteIndex !== -1
       ? firstIncompleteIndex

--- a/src/pages/daily-routine/ui/DailyRoutinePage.tsx
+++ b/src/pages/daily-routine/ui/DailyRoutinePage.tsx
@@ -1,6 +1,9 @@
+import type { ReactNode } from "react";
 import { useNavigate, useSearchParams } from "react-router";
 import { useStartSession } from "@/entities/session";
 import { toDailyRoutineExercisePath, toSessionPath } from "@/shared/config/routes";
+import { cn } from "@/shared/lib/cn";
+import { useInView } from "@/shared/lib/use-in-view";
 import { CTAButton } from "@/shared/ui/button";
 import { CroppedWorkoutImage } from "@/shared/ui/cropped-workout-image";
 import { AlarmIcon, FireIcon, HumanIcon } from "@/shared/ui/icons";
@@ -10,6 +13,24 @@ import { SummaryCard, type SummaryCardChip } from "@/shared/ui/summary-card";
 import { TopNavBar } from "@/shared/ui/top-nav-bar";
 import { useCourse } from "../api/use-course";
 import { mapCourseDetailResponse } from "../api/map-course";
+
+/** 코스 순서 줄이 스크롤로 뷰포트에 들어올 때 은은하게 떠오르며 나타난다 */
+function RevealOnScroll({ className, children }: { className?: string; children: ReactNode }) {
+  const { ref, isInView } = useInView<HTMLDivElement>();
+
+  return (
+    <div
+      ref={ref}
+      className={cn(
+        "transition-[opacity,transform] duration-500 ease-[cubic-bezier(0.23,1,0.32,1)] motion-reduce:transition-opacity",
+        isInView ? "translate-y-0 opacity-100" : "translate-y-[1.6rem] opacity-0",
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+}
 
 export function DailyRoutinePage() {
   const navigate = useNavigate();
@@ -85,35 +106,36 @@ export function DailyRoutinePage() {
         <h2 className="typo-title-3-emphasized text-black">코스 순서</h2>
         <div className="flex w-full flex-col items-start">
           {exercises.map((row, index) => (
-            <button
-              key={row.exercise.exerciseId}
-              type="button"
-              onClick={() =>
-                navigate(toDailyRoutineExercisePath(String(row.exercise.exerciseId)), {
-                  // 상세 API가 느려서, 코스 순서에서 이미 알고 있는 값으로 먼저 그린다.
-                  state: {
-                    courseId,
-                    stepOrder: row.stepOrder,
-                    name: row.exercise.name,
-                    imageSrc: row.exercise.imageSrc,
-                    step: { current: index + 1, total: exercises.length },
-                  },
-                })
-              }
-              className="w-full text-left"
-            >
-              <SequenceItem
-                step={index + 1}
-                active={index === activeIndex}
-                isLast={index === exercises.length - 1}
-                imageSrc={row.exercise.imageSrc}
-                alt={row.exercise.name}
-                title={row.exercise.name}
-                descriptions={[row.exercise.category, row.exercise.setInfo]}
-                captionIcon={<FireIcon />}
-                caption={`${row.exercise.kcal ?? "-"}kcal`}
-              />
-            </button>
+            <RevealOnScroll key={row.exercise.exerciseId} className="w-full">
+              <button
+                type="button"
+                onClick={() =>
+                  navigate(toDailyRoutineExercisePath(String(row.exercise.exerciseId)), {
+                    // 상세 API가 느려서, 코스 순서에서 이미 알고 있는 값으로 먼저 그린다.
+                    state: {
+                      courseId,
+                      stepOrder: row.stepOrder,
+                      name: row.exercise.name,
+                      imageSrc: row.exercise.imageSrc,
+                      step: { current: index + 1, total: exercises.length },
+                    },
+                  })
+                }
+                className="w-full text-left transition-transform duration-150 ease-out active:scale-[0.98] [@media(hover:hover)_and_(pointer:fine)]:hover:opacity-90"
+              >
+                <SequenceItem
+                  step={index + 1}
+                  active={row.active}
+                  isLast={index === exercises.length - 1}
+                  imageSrc={row.exercise.imageSrc}
+                  alt={row.exercise.name}
+                  title={row.exercise.name}
+                  descriptions={[row.exercise.category, row.exercise.setInfo]}
+                  captionIcon={<FireIcon />}
+                  caption={`${row.exercise.kcal ?? "-"}kcal`}
+                />
+              </button>
+            </RevealOnScroll>
           ))}
         </div>
       </div>

--- a/src/pages/exercise-detail/ui/ExerciseDetailPage.tsx
+++ b/src/pages/exercise-detail/ui/ExerciseDetailPage.tsx
@@ -109,7 +109,9 @@ export function ExerciseDetailPage() {
               </span>
               <div className="flex flex-col gap-[0.8rem]">
                 <p className="typo-headline-emphasized text-gray-10">핵심 동작</p>
-                <p className="typo-body-regular whitespace-pre-line text-gray-30">{guide.tip}</p>
+                <p className="typo-body-regular whitespace-pre-line break-keep text-gray-30">
+                  {guide.tip}
+                </p>
               </div>
             </div>
           </div>

--- a/src/pages/home/ui/CourseProgressCard.tsx
+++ b/src/pages/home/ui/CourseProgressCard.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import { cn } from "@/shared/lib/cn";
 import type { CourseProgress } from "@/entities/course";
 
@@ -16,6 +17,13 @@ export default function CourseProgressCard({ progress, className }: CourseProgre
   const isCompleted = current !== null && total !== null && current >= total;
   const label = isCompleted ? "동작 진행도" : "현재 코스 진행도";
 
+  // 마운트 시 0%로 그린 뒤 다음 프레임에 실제 값으로 바꿔야 채워지는 애니메이션이 재생된다
+  const [isVisible, setIsVisible] = useState(false);
+  useEffect(() => {
+    const raf = requestAnimationFrame(() => setIsVisible(true));
+    return () => cancelAnimationFrame(raf);
+  }, []);
+
   return (
     <div className={cn("flex flex-col gap-[1.5rem]", className)}>
       <p className="typo-subheadline-emphasized text-gray-10">{label}</p>
@@ -33,8 +41,8 @@ export default function CourseProgressCard({ progress, className }: CourseProgre
           className="relative h-[0.6rem] w-full overflow-hidden rounded-[10rem] bg-gray-98"
         >
           <div
-            className="absolute inset-y-0 left-0 rounded-[10rem] bg-secondary-400"
-            style={{ width: `${percent}%` }}
+            className="absolute inset-y-0 left-0 rounded-[10rem] bg-secondary-400 transition-[width] duration-700 ease-[cubic-bezier(0.23,1,0.32,1)] motion-reduce:duration-0"
+            style={{ width: `${isVisible ? percent : 0}%` }}
           />
         </div>
         <div className="flex items-center justify-between typo-caption-1-regular">

--- a/src/pages/pose-challenge/ui/PoseChallengePage.tsx
+++ b/src/pages/pose-challenge/ui/PoseChallengePage.tsx
@@ -1,12 +1,17 @@
 import { useState } from "react";
 import { useNavigate } from "react-router";
 import type { PoseChallengeStatus } from "@/entities/pose";
+import { cn } from "@/shared/lib/cn";
 import { Button } from "@/shared/ui/button";
 import { ProgressRingItem, type ProgressRingItemProps } from "@/shared/ui/progress-ring-item";
 import { Skeleton } from "@/shared/ui/skeleton";
 import { TopNavBar } from "@/shared/ui/top-nav-bar";
 import { mapPoseChallengeProgress } from "../api/map-pose-challenge";
 import { useBodyParts, useTargetPoseProgress } from "../api/use-pose-challenge-progress";
+
+const TRANSITION_DURATION = 300;
+const STAGGER_STEP = 30;
+const STAGGER_MAX_STEPS = 8;
 
 type PoseFilter = "all" | Exclude<PoseChallengeStatus, "idle">;
 
@@ -52,16 +57,6 @@ export function PoseChallengePage() {
 
   const view = mapPoseChallengeProgress(progressQuery.data, bodyPartsQuery.data);
 
-  const filteredGroups =
-    filter === "all"
-      ? view.groups
-      : view.groups
-          .map((group) => ({
-            ...group,
-            poses: group.poses.filter((pose) => pose.status === filter),
-          }))
-          .filter((group) => group.poses.length > 0);
-
   const tabs: { key: PoseFilter; label: string }[] = [
     { key: "all", label: `전체 ${view.totalCount}` },
     { key: "inProgress", label: `도전 중 ${view.inProgressCount}` },
@@ -96,30 +91,45 @@ export function PoseChallengePage() {
         ))}
       </div>
 
+      {/* body part 영역(제목+그리드)은 필터와 무관하게 항상 그대로 두고, 그 안의 카드만 나타났다 사라진다 —
+          카드 개수만큼 그리드가 접히지 않도록 group.poses는 필터링하지 않고 전부 렌더링한다. */}
       <div className="mt-[2.4rem] flex w-full flex-col gap-[2.4rem]">
-        {filteredGroups.map(({ bodyPart, poses }) => (
+        {view.groups.map(({ bodyPart, poses }) => (
           <div key={bodyPart} className="flex w-full flex-col gap-[0.8rem]">
             <h2 className="typo-body-emphasized w-full text-black">{bodyPart}</h2>
             <div className="grid w-full grid-cols-3 gap-x-[1.45rem] gap-y-[1.6rem]">
-              {poses.map((pose) => (
-                <ProgressRingItem
-                  key={pose.id}
-                  imageSrc={pose.imageSrc}
-                  alt={pose.name}
-                  label={pose.name}
-                  current={pose.current}
-                  total={pose.total}
-                  status={RING_STATUS[pose.status]}
-                  badgeLabel={
-                    pose.status === "idle"
-                      ? undefined
-                      : pose.status === "completed"
-                        ? "완성"
-                        : `${pose.current}/${pose.total}`
-                  }
-                  className="w-full"
-                />
-              ))}
+              {poses.map((pose, index) => {
+                const visible = filter === "all" || pose.status === filter;
+                return (
+                  <ProgressRingItem
+                    key={pose.id}
+                    imageSrc={pose.imageSrc}
+                    alt={pose.name}
+                    label={pose.name}
+                    current={pose.current}
+                    total={pose.total}
+                    status={RING_STATUS[pose.status]}
+                    badgeLabel={
+                      pose.status === "idle"
+                        ? undefined
+                        : pose.status === "completed"
+                          ? "완성"
+                          : `${pose.current}/${pose.total}`
+                    }
+                    aria-hidden={!visible}
+                    className={cn(
+                      "w-full transition-all ease-out",
+                      visible ? "scale-100 opacity-100" : "pointer-events-none scale-90 opacity-0",
+                    )}
+                    style={{
+                      transitionDuration: `${TRANSITION_DURATION}ms`,
+                      transitionDelay: visible
+                        ? `${Math.min(index, STAGGER_MAX_STEPS) * STAGGER_STEP}ms`
+                        : "0ms",
+                    }}
+                  />
+                );
+              })}
             </div>
           </div>
         ))}

--- a/src/pages/session/ui/SessionPlayerPage.tsx
+++ b/src/pages/session/ui/SessionPlayerPage.tsx
@@ -66,6 +66,7 @@ export function SessionPlayerPage() {
     <main className="relative flex min-h-screen flex-col bg-white">
       <TopNavBar
         onBack={() => navigate(-1)}
+        className="px-[2rem]"
         // TODO: 음소거 버튼 추가
         // rightIcon={SoundIcon}
         // rightIconLabel={muted ? "음소거 해제" : "음소거"}

--- a/src/shared/lib/use-in-view.ts
+++ b/src/shared/lib/use-in-view.ts
@@ -1,0 +1,40 @@
+import { useEffect, useRef, useState } from "react";
+
+interface UseInViewOptions {
+  /** 요소가 몇 % 보여야 in-view로 볼지 */
+  threshold?: number;
+  /** 뷰포트 경계를 안쪽으로 당겨서, 화면에 딱 들어오기 전에 미리 트리거하고 싶을 때 사용 */
+  rootMargin?: string;
+}
+
+/**
+ * 요소가 뷰포트에 처음 들어오는 시점을 감지한다. 스크롤 reveal 같은
+ * 1회성 진입 애니메이션 트리거용 — 한 번 보이면 다시 관찰하지 않는다.
+ */
+export function useInView<T extends HTMLElement>({
+  threshold = 0.2,
+  rootMargin = "0px 0px -10% 0px",
+}: UseInViewOptions = {}) {
+  const ref = useRef<T>(null);
+  const [isInView, setIsInView] = useState(false);
+
+  useEffect(() => {
+    const element = ref.current;
+    if (!element || isInView) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsInView(true);
+          observer.disconnect();
+        }
+      },
+      { threshold, rootMargin },
+    );
+
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [isInView, threshold, rootMargin]);
+
+  return { ref, isInView };
+}

--- a/src/shared/ui/bottom-tab-bar/BottomTabBar.tsx
+++ b/src/shared/ui/bottom-tab-bar/BottomTabBar.tsx
@@ -22,13 +22,26 @@ export default function BottomTabBar<T extends string>({
   onTabChange,
   className,
 }: BottomTabBarProps<T>) {
+  const activeIndex = Math.max(
+    tabs.findIndex((tab) => tab.id === activeTab),
+    0,
+  );
+
   return (
     <nav
       className={cn(
-        "flex items-center gap-[0.4rem] rounded-[2rem] bg-white/50 p-[0.4rem] shadow-tab-bar backdrop-blur-[0.5rem]",
+        "relative flex items-center gap-[0.4rem] rounded-[2rem] bg-white/50 p-[0.4rem] shadow-tab-bar backdrop-blur-[0.5rem]",
         className,
       )}
     >
+      <div
+        aria-hidden="true"
+        className="absolute inset-y-[0.4rem] left-[0.4rem] rounded-[1.6rem] bg-gray-98 transition-transform duration-[250ms] ease-[cubic-bezier(0.23,1,0.32,1)]"
+        style={{
+          width: `calc((100% - 0.4rem) / ${tabs.length})`,
+          transform: `translateX(${activeIndex * 100}%)`,
+        }}
+      />
       {tabs.map(({ id, label, filledIcon, outlineIcon }) => (
         <TabItem
           key={id}

--- a/src/shared/ui/bottom-tab-bar/TabItem.tsx
+++ b/src/shared/ui/bottom-tab-bar/TabItem.tsx
@@ -15,11 +15,11 @@ export default function TabItem({ icon, label, isActive, onClick }: TabItemProps
       icon={icon}
       aria-label={label}
       onClick={onClick}
-      className={cn(
-        "flex items-center justify-center rounded-[1.6rem] px-[3.3rem] py-[1.9rem]",
-        isActive && "bg-gray-98",
+      className="relative z-10 flex flex-1 items-center justify-center rounded-[1.6rem] px-[3.3rem] py-[1.9rem]"
+      iconClassName={cn(
+        "transition-colors duration-200",
+        isActive ? "text-gray-10" : "text-gray-70",
       )}
-      iconClassName={isActive ? "text-gray-10" : "text-gray-70"}
     />
   );
 }

--- a/src/shared/ui/modal/Modal.tsx
+++ b/src/shared/ui/modal/Modal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useId } from "react";
+import { useEffect, useId, useState } from "react";
 import { createPortal } from "react-dom";
 import { cn } from "@/shared/lib/cn";
 
@@ -27,6 +27,16 @@ export default function Modal({
   className,
 }: ModalProps) {
   const titleId = useId();
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    const raf = requestAnimationFrame(() => setVisible(true));
+    return () => {
+      cancelAnimationFrame(raf);
+      setVisible(false);
+    };
+  }, [open]);
 
   useEffect(() => {
     if (!open) return;
@@ -48,13 +58,21 @@ export default function Modal({
 
   return createPortal(
     <div className="fixed inset-0 z-50 flex items-center justify-center px-[2rem]">
-      <div aria-hidden="true" onClick={onDismiss} className="absolute inset-0 bg-overlay-dim" />
+      <div
+        aria-hidden="true"
+        onClick={onDismiss}
+        className={cn(
+          "absolute inset-0 bg-overlay-dim transition-opacity duration-200 ease-out",
+          visible ? "opacity-100" : "opacity-0",
+        )}
+      />
       <div
         role="dialog"
         aria-modal="true"
         aria-labelledby={titleId}
         className={cn(
-          "relative flex w-full min-w-[32rem] max-w-[40rem] flex-col overflow-hidden rounded-[1.6rem] bg-bg-surface",
+          "relative flex w-full min-w-[32rem] max-w-[40rem] flex-col overflow-hidden rounded-[1.6rem] bg-bg-surface transition-[transform,opacity] duration-200 ease-[cubic-bezier(0.23,1,0.32,1)]",
+          visible ? "scale-100 opacity-100" : "scale-95 opacity-0",
           className,
         )}
       >


### PR DESCRIPTION
## Summary

데일리 루틴 코스 순서 리스트, 하단 탭바, 홈 코스 진행도 프로그레스바, 확인 모달에 은은한 상태 전환 인터랙션을 추가했다. 순간적으로 값이 튀던 부분들을 fade/scale/width 트랜지션으로 부드럽게 만든다.

## Related Issues

- close #75

## PR Point (To Reviewer)

- 데일리 루틴 리스트 항목은 `IntersectionObserver` 기반 `useInView` 훅(`shared/lib`)으로 스크롤 진입을 감지해 1회성으로 fade+rise한다.
- 모달은 `prefers-reduced-motion: reduce`에서 트랜지션이 생략되도록 처리했다.
- 마지막 커밋(`fix: 스크롤 복원, 코스 진행 활성 판정, ...`)은 이슈 #75와 무관하게 이미 진행 중이던 잡음 수정들이다 — 스크롤 복원 버그, 코스 진행 active 판정 로직, 텍스트 줄바꿈, 포즈 챌린지 필터 트랜지션, 세션 플레이어 패딩. 별도 이슈 없이 이번 브랜치에 같이 실었다.

## Screenshot

해당 없음

## ETC

없음