### PR TITLE
fix: 로그인 흐름 정리 및 라우트 접근 가드 중앙화

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -12,19 +12,24 @@ export function App() {
         <ScrollToTop />
         <Layout>
           <Routes>
-            {Object.entries(APP_ROUTES).map(([key, group]) =>
-              group.layout ? (
-                <Route key={key} element={group.layout}>
-                  {group.paths.map(({ path, element }) => (
-                    <Route key={path} path={path} element={element} />
-                  ))}
+            {Object.entries(APP_ROUTES).map(([key, group]) => {
+              const paths = group.paths.map(({ path, element }) => (
+                <Route key={path} path={path} element={element} />
+              ));
+              const withLayout = group.layout ? (
+                <Route element={group.layout}>{paths}</Route>
+              ) : (
+                paths
+              );
+
+              return group.guard ? (
+                <Route key={key} element={group.guard}>
+                  {withLayout}
                 </Route>
               ) : (
-                group.paths.map(({ path, element }) => (
-                  <Route key={path} path={path} element={element} />
-                ))
-              ),
-            )}
+                withLayout
+              );
+            })}
           </Routes>
         </Layout>
       </BrowserRouter>

--- a/src/app/model/RequireAccessState.tsx
+++ b/src/app/model/RequireAccessState.tsx
@@ -1,0 +1,25 @@
+import { Navigate, Outlet } from "react-router";
+import { ROUTES, type RoutePath } from "@/shared/config/routes";
+import { useAccessState, type AccessState } from "./use-access-state";
+
+type RequiredAccessState = Exclude<AccessState, "checking">;
+
+const TARGET_ROUTE: Record<RequiredAccessState, RoutePath> = {
+  login: ROUTES.login,
+  onboarding: ROUTES.onboarding,
+  screening: ROUTES.screening,
+  ready: ROUTES.home,
+};
+
+type RequireAccessStateProps = {
+  allow: RequiredAccessState[];
+};
+
+export function RequireAccessState({ allow }: RequireAccessStateProps) {
+  const accessState = useAccessState();
+
+  if (accessState === "checking") return null;
+  if (!allow.includes(accessState)) return <Navigate to={TARGET_ROUTE[accessState]} replace />;
+
+  return <Outlet />;
+}

--- a/src/app/model/use-access-state.ts
+++ b/src/app/model/use-access-state.ts
@@ -1,0 +1,42 @@
+import { useQuery } from "@tanstack/react-query";
+import { hasCompletedOnboarding, useMemberProfile } from "@/entities/member";
+import { isAuthenticated, screeningApi } from "@/shared/api";
+
+export type AccessState = "checking" | "login" | "onboarding" | "screening" | "ready";
+
+const SCREENING_EXISTS_QUERY_KEY = ["screening", "latest", "exists"] as const;
+
+// 진단 이력이 없으면 404다 — 상태 코드를 보지 않고 실패 자체를 "이력 없음"으로 취급한다
+// (features/screening-flow/steps/DiagnosisStep.tsx와 동일한 규칙).
+async function hasScreeningResult() {
+  try {
+    await screeningApi.getLatestResult();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// 앱 전체 라우트가 공유하는 상태 머신: 인증 → 프로필(온보딩) → 자가진단(부위 선택 포함) 순으로 확인한다.
+export function useAccessState(): AccessState {
+  const authenticated = isAuthenticated();
+  const { data: member, isPending: isMemberPending } = useMemberProfile({
+    enabled: authenticated,
+  });
+  const isOnboarded = member != null && hasCompletedOnboarding(member);
+  // 진단 결과를 본 뒤에 고르는 값이라 스크리닝 자체를 안 했어도, 했는데 아직 안 골랐어도 null이다.
+  const isBodyPartChosen = member?.reinforcementBodyPartCode != null;
+
+  const { data: hasScreened, isPending: isScreeningPending } = useQuery({
+    queryKey: SCREENING_EXISTS_QUERY_KEY,
+    queryFn: hasScreeningResult,
+    enabled: authenticated && isOnboarded,
+  });
+
+  if (!authenticated) return "login";
+  if (isMemberPending) return "checking";
+  if (!isOnboarded) return "onboarding";
+  if (isScreeningPending) return "checking";
+  if (hasScreened === false || !isBodyPartChosen) return "screening";
+  return "ready";
+}

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 import { ROUTES, type RoutePath } from "@/shared/config/routes";
 import { TabLayout } from "./layouts/TabLayout";
+import { RequireAccessState } from "./model/RequireAccessState";
 
 import { CompletePage } from "@/pages/complete";
 import { CourseRecommendationPage } from "@/pages/course-recommendation";
@@ -21,26 +22,53 @@ type AppRoute = {
 };
 
 type RouteGroup = {
+  guard: ReactNode | undefined;
   layout: ReactNode | undefined;
   paths: AppRoute[];
 };
 
-export const APP_ROUTES: Record<"tab" | "bare", RouteGroup> = {
+export const APP_ROUTES: Record<
+  "login" | "loginCallback" | "onboarding" | "screening" | "tab" | "ready",
+  RouteGroup
+> = {
+  // 로그인이 안 되어 있을 때만 보여준다 — 이미 로그인돼 있으면 온보딩/스크리닝/홈 중 맞는 곳으로 보낸다.
+  login: {
+    guard: <RequireAccessState allow={["login"]} />,
+    layout: undefined,
+    paths: [{ path: ROUTES.login, element: <Login /> }],
+  },
+  // 카카오 인가 코드 교환용 콜백 — 로그인 진행 중이라 인증 상태를 아직 확정할 수 없으니 가드하지 않는다.
+  loginCallback: {
+    guard: undefined,
+    layout: undefined,
+    paths: [{ path: ROUTES.loginCallback, element: <LoginCallback /> }],
+  },
+  // 프로필(키/몸무게/운동 경력)이 없을 때만 보여준다.
+  onboarding: {
+    guard: <RequireAccessState allow={["onboarding"]} />,
+    layout: undefined,
+    paths: [{ path: ROUTES.onboarding, element: <OnboardingPage /> }],
+  },
+  // 첫 진단이 없을 때 + 이미 다 끝난 회원이 "난이도 조정하기"로 재방문할 때(MuscleTargetCard) 둘 다 허용한다.
+  screening: {
+    guard: <RequireAccessState allow={["screening", "ready"]} />,
+    layout: undefined,
+    paths: [{ path: ROUTES.screening, element: <ScreeningPage /> }],
+  },
+  // 로그인 + 프로필 + 자가진단(부위 선택 포함)까지 모두 끝났을 때만 들어올 수 있다.
   tab: {
+    guard: <RequireAccessState allow={["ready"]} />,
     layout: <TabLayout />,
     paths: [
       { path: ROUTES.home, element: <HomePage /> },
       { path: ROUTES.my, element: <MyPage /> },
     ],
   },
-  bare: {
+  ready: {
+    guard: <RequireAccessState allow={["ready"]} />,
     layout: undefined,
     paths: [
-      { path: ROUTES.login, element: <Login /> },
-      { path: ROUTES.loginCallback, element: <LoginCallback /> },
-      { path: ROUTES.onboarding, element: <OnboardingPage /> },
       { path: ROUTES.courseRecommendation, element: <CourseRecommendationPage /> },
-      { path: ROUTES.screening, element: <ScreeningPage /> },
       { path: ROUTES.dailyRoutine, element: <DailyRoutinePage /> },
       { path: ROUTES.dailyRoutineExercise, element: <ExerciseDetailPage /> },
       { path: ROUTES.poseChallenge, element: <PoseChallengePage /> },

--- a/src/entities/member/index.ts
+++ b/src/entities/member/index.ts
@@ -1,4 +1,5 @@
 export type { Member } from "./model/member";
+export { hasCompletedOnboarding } from "./model/member";
 export { useMemberProfile } from "./model/use-member-profile";
 export { useUpdateMemberProfile } from "./model/use-update-member-profile";
 export { useWithdrawMember } from "./model/use-withdraw-member";

--- a/src/entities/member/model/member.ts
+++ b/src/entities/member/model/member.ts
@@ -5,3 +5,8 @@ export type Member = MemberProfileResponse;
 export const memberQueryKeys = {
   me: ["member", "me"] as const,
 };
+
+// heightCm/weightKg/experienceLevel은 온보딩 전이면 null이다 (MemberProfileResponse 참고).
+export function hasCompletedOnboarding(member: Member) {
+  return member.heightCm != null && member.weightKg != null && member.experienceLevel != null;
+}

--- a/src/entities/member/model/use-member-profile.ts
+++ b/src/entities/member/model/use-member-profile.ts
@@ -2,12 +2,13 @@ import { useQuery } from "@tanstack/react-query";
 import { membersApi } from "@/shared/api";
 import { memberQueryKeys, type Member } from "./member";
 
-export function useMemberProfile() {
+export function useMemberProfile(options?: { enabled?: boolean }) {
   return useQuery<Member>({
     queryKey: memberQueryKeys.me,
     queryFn: async () => {
       const response = await membersApi.getMyProfile();
       return response.data;
     },
+    enabled: options?.enabled,
   });
 }

--- a/src/features/onboarding-form/constants/pose-images.ts
+++ b/src/features/onboarding-form/constants/pose-images.ts
@@ -4,11 +4,13 @@ import 반보트 from "@/shared/assets/imgs/반보트.png";
 import 보트 from "@/shared/assets/imgs/보트.png";
 import 브릿지 from "@/shared/assets/imgs/브릿지.png";
 import 사이드플랭크 from "@/shared/assets/imgs/사이드플랭크.png";
+import 업독 from "@/shared/assets/imgs/target-pose/업독.png";
 import 파이어로그 from "@/shared/assets/imgs/파이어로그.png";
 import 휠 from "@/shared/assets/imgs/휠.png";
 
 // GET /catalog/target-poses의 targetPoseId 기준 (dev API로 확인한 실제 값). 서버의 imageAssetKey는 쓰지 않는다
 const POSE_IMAGE_BY_TARGET_POSE_ID: Record<number, string> = {
+  1: 업독,
   2: 낙타,
   3: 휠,
   4: 반보트,

--- a/src/pages/login/ui/LoginCallback.tsx
+++ b/src/pages/login/ui/LoginCallback.tsx
@@ -23,7 +23,7 @@ export function LoginCallback() {
 
     loginWithKakaoCode(code).then((result) => {
       if (result.success) {
-        navigate(ROUTES.onboarding, { replace: true });
+        navigate(ROUTES.home, { replace: true });
       } else {
         navigate(ROUTES.login, { replace: true, state: { error: result.message } });
       }

--- a/src/shared/api/access-token.ts
+++ b/src/shared/api/access-token.ts
@@ -1,14 +1,14 @@
 const ACCESS_TOKEN_KEY = "accessToken";
 
-export const getAccessToken = () => sessionStorage.getItem(ACCESS_TOKEN_KEY);
+export const getAccessToken = () => localStorage.getItem(ACCESS_TOKEN_KEY);
 
 export const setAccessToken = (token: string | null) => {
   if (!token) {
-    sessionStorage.removeItem(ACCESS_TOKEN_KEY);
+    localStorage.removeItem(ACCESS_TOKEN_KEY);
     return;
   }
 
-  sessionStorage.setItem(ACCESS_TOKEN_KEY, token);
+  localStorage.setItem(ACCESS_TOKEN_KEY, token);
 };
 
 export const isAuthenticated = () => getAccessToken() !== null;


### PR DESCRIPTION
## Summary

- 액세스 토큰 저장소를 sessionStorage에서 localStorage로 변경
- 로그인/온보딩/자가진단 여부에 따른 라우트 접근 제어를 app 레이어에 중앙화(`useAccessState` + `RequireAccessState`) — 로그인 콜백은 이제 항상 홈으로 보내고, 실제 리다이렉트는 가드가 판단
- 온보딩 자세 그리드에서 targetPoseId 1(업독)이 파이어로그 이미지로 잘못 대체되던 매핑 누락 수정

## Related Issues

- 필드된 이슈 없음 (대화 중 발견/논의된 내용을 바로 작업)

## PR Point (To Reviewer)

- `/screening`은 "자가진단 미완료"뿐 아니라 "이미 완료한 회원이 난이도 조정하러 재방문"하는 경우도 있어서, 가드가 `["screening", "ready"]` 둘 다 허용하도록 했습니다. 처음엔 정확히 하나만 허용했다가 "난이도 조정하기" 버튼이 홈으로 튕기는 버그를 실제로 재현해서 고쳤습니다.
- 업독 이미지는 임시로 `entities/course`가 쓰는 것과 같은 에셋을 재사용했는데, 그 에셋 자체가 실은 "활" 자세 사진이 잘못 들어가 있는 상태입니다(코드에 TODO로 남겨둠). 온보딩뿐 아니라 홈/데일리루틴/자세도전 등 앱 전체에 영향 있는 별도 이슈라 이번 PR 범위에서는 다루지 않았습니다.
- 인증된 상태(ready/screening)에서의 라우트 가드 동작은 로컬 dev API가 CORS로 막혀 있어 자동화 테스트로는 검증 못 했고, 비인증 리다이렉트만 브라우저(Playwright)로 확인했습니다. "난이도 조정하기" 등 인증 이후 플로우는 실제 계정으로 수동 확인했습니다.

## Screenshot

<!-- 라우팅/로직 변경 위주라 스크린샷 생략 -->

## ETC