### PR TITLE
fix: 미인증 상태에서 body-parts 프리페치가 401 리로드 루프를 유발하는 문제 수정

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -6,12 +6,17 @@ import { getBodyParts } from "@/features/screening-flow";
 import { Layout } from "./layouts/Layout";
 import { APP_ROUTES } from "./routes";
 import { ScrollToTop } from "./ScrollToTop";
+import { isAuthenticated } from "@/shared/api";
 import { queryClient } from "@/shared/config/query-client";
 
 export function App() {
   // 부위 목록은 유저 입력과 무관한 고정 참조 데이터라 앱 시작 시 미리 당겨둔다
   // (온보딩·스크리닝 진단 화면이 나중에 다시 fetch하지 않고 이 캐시를 그대로 쓴다).
+  // 인증된 사용자만 접근하는 화면에서 쓰이므로, 로그인 전에는 요청하지 않는다
+  // (보안 엔드포인트라 미인증 요청은 401 → 강제 리로드를 반복 트리거한다).
   useEffect(() => {
+    if (!isAuthenticated()) return;
+
     queryClient.prefetchQuery({
       queryKey: bodyPartsQueryKey(),
       queryFn: getBodyParts,


### PR DESCRIPTION
## Summary

App 마운트 시 인증 여부와 무관하게 인증 필요 엔드포인트(`GET /screening/body-parts`)를 프리페치하고 있었다. 토큰이 없는 상태(`/login`)에서도 이 요청이 나가 401이 발생했고, 401 응답 훅이 `window.location.href`로 강제 풀 리로드를 시키면서 로그인 페이지가 계속 새로고침/깜빡이는 무한 루프가 발생했다. 인증된 사용자에게만 프리페치하도록 가드를 추가했다.

## Related Issues

<!--관련 이슈 언급 -->

- 연결된 이슈 없음 (로그인 페이지 리렌더링/깜빡임 버그 대응 중 발견)

## PR Point (To Reviewer)

`prefetchQuery`는 `useQuery`와 달리 `enabled` 옵션을 지원하지 않아, `useEffect` 내부에서 `isAuthenticated()`로 조건문 가드를 걸었다. 이 때문에 앱이 최초 마운트된 이후 세션 중 로그인한 경우(예: `/login`에서 로그인 후 SPA 네비게이션으로 홈 이동)에는 이 prefetch가 다시 실행되지 않는다 — 온보딩/스크리닝 화면이 자체적으로 `getBodyParts`를 호출하므로 기능상 문제는 없고, 캐시 워밍 최적화 효과만 그 경로에서 빠진다. 문제 없다고 보지만 트레이드오프로 공유한다.

## Screenshot

해당 없음

## ETC

없음