### PR TITLE
fix: 코스 상세를 거쳐야 세션에 진입하도록 하고 여러 화면의 뒤로가기를 고정 목적지로 변경

### DIFF
--- a/src/entities/course/index.ts
+++ b/src/entities/course/index.ts
@@ -1,6 +1,16 @@
 export type { CourseProgress, TodayWorkoutSummary, PoseTip } from "./model/types";
 export type { Course, CourseStep, CourseStepExercise } from "./model/course-detail";
 export { courseDetailQueryKey, getCourseDetail, useCourseDetail } from "./model/course-detail";
+export type {
+  DailyRoutineExerciseView,
+  DailyRoutineExerciseRowView,
+  CourseDetailView,
+} from "./model/course-detail-view";
+export {
+  mapCourseDetailResponse,
+  useCourseDetailView,
+  findAdjacentExerciseRow,
+} from "./model/course-detail-view";
 export type { BodyPartCode } from "./model/labels";
 export {
   BODY_PART_LABELS,

--- a/src/entities/course/model/course-detail-view.ts
+++ b/src/entities/course/model/course-detail-view.ts
@@ -1,13 +1,12 @@
-import {
-  getPoseImageSrc,
-  isCourseCompleted,
-  resolveThumbnailSrc,
-  type TodayWorkoutSummary,
-} from "@/entities/course";
+import { useQuery } from "@tanstack/react-query";
+import { coursesApi } from "@/shared/api";
 import type {
   CourseDetailResponse,
   CourseStepExerciseResponse,
 } from "@/shared/api/generated/data-contracts";
+import { isCourseCompleted } from "./lib";
+import { getPoseImageSrc, resolveThumbnailSrc } from "./pose-images";
+import type { TodayWorkoutSummary } from "./types";
 
 export interface DailyRoutineExerciseView {
   exerciseId: number;
@@ -104,4 +103,38 @@ export function mapCourseDetailResponse(response: CourseDetailResponse): CourseD
     activeIndex,
     exercises,
   };
+}
+
+export function courseDetailViewQueryKey(courseId: number) {
+  return ["courses", courseId, "view"] as const;
+}
+
+export function useCourseDetailView(courseId: number | null) {
+  return useQuery({
+    queryKey: courseDetailViewQueryKey(courseId as number),
+    queryFn: async () => {
+      const response = await coursesApi.getCourseDetail(courseId as number);
+      return mapCourseDetailResponse(response.data);
+    },
+    enabled: courseId !== null,
+  });
+}
+
+/** exercises는 stepOrder 오름차순이라고 가정한다(mapCourseDetailResponse가 그렇게 만든다) */
+export function findAdjacentExerciseRow(
+  exercises: DailyRoutineExerciseRowView[],
+  currentStepOrder: number,
+  direction: "previous" | "next",
+): { index: number; row: DailyRoutineExerciseRowView } | null {
+  if (direction === "next") {
+    const index = exercises.findIndex((row) => row.stepOrder > currentStepOrder);
+    return index === -1 ? null : { index, row: exercises[index] };
+  }
+
+  let index = -1;
+  for (let i = 0; i < exercises.length; i++) {
+    if (exercises[i].stepOrder >= currentStepOrder) break;
+    index = i;
+  }
+  return index === -1 ? null : { index, row: exercises[index] };
 }

--- a/src/pages/daily-routine/ui/DailyRoutinePage.tsx
+++ b/src/pages/daily-routine/ui/DailyRoutinePage.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from "react";
 import { useNavigate, useSearchParams } from "react-router";
-import { useStartSession } from "@/entities/session";
-import { toDailyRoutineExercisePath, toSessionPath } from "@/shared/config/routes";
+import { mapCourseDetailResponse } from "@/entities/course";
+import { ROUTES, toDailyRoutineExercisePath } from "@/shared/config/routes";
 import { cn } from "@/shared/lib/cn";
 import { useInView } from "@/shared/lib/use-in-view";
 import { CTAButton } from "@/shared/ui/button";
@@ -13,7 +13,6 @@ import { Skeleton } from "@/shared/ui/skeleton";
 import { SummaryCard, type SummaryCardChip } from "@/shared/ui/summary-card";
 import { TopNavBar } from "@/shared/ui/top-nav-bar";
 import { useCourse } from "../api/use-course";
-import { mapCourseDetailResponse } from "../api/map-course";
 
 /** 코스 순서 줄이 스크롤로 뷰포트에 들어올 때 은은하게 떠오르며 나타난다 */
 function RevealOnScroll({ className, children }: { className?: string; children: ReactNode }) {
@@ -40,7 +39,6 @@ export function DailyRoutinePage() {
   const courseId = courseIdParam !== null ? Number(courseIdParam) : null;
 
   const { data, error, isPending } = useCourse(courseId);
-  const startSession = useStartSession();
 
   if (courseId === null) {
     return null;
@@ -50,7 +48,7 @@ export function DailyRoutinePage() {
     return (
       <main className="relative flex min-h-screen flex-col items-center px-[2rem] pb-[10rem]">
         <TopNavBar
-          onBack={() => navigate(-1)}
+          onBack={() => navigate(ROUTES.home)}
           className="w-full"
           children={<span className="typo-headline-emphasized text-black">데일리 루틴</span>}
         />
@@ -87,7 +85,7 @@ export function DailyRoutinePage() {
   return (
     <main className="relative flex min-h-screen flex-col items-center px-[2rem] pb-[10rem]">
       <TopNavBar
-        onBack={() => navigate(-1)}
+        onBack={() => navigate(ROUTES.home)}
         className="w-full"
         children={<span className="typo-headline-emphasized text-black">데일리 루틴</span>}
       />
@@ -144,13 +142,19 @@ export function DailyRoutinePage() {
 
       <CTAButton>
         <CTAButton.Single
-          disabled={completed || startSession.isPending}
+          disabled={completed}
           onClick={() => {
             if (activeIndex === null) return;
-            startSession.mutate(
-              { courseId, stepOrder: exercises[activeIndex].stepOrder },
-              { onSuccess: (session) => navigate(toSessionPath(session.sessionId as number)) },
-            );
+            const activeRow = exercises[activeIndex];
+            navigate(toDailyRoutineExercisePath(String(activeRow.exercise.exerciseId)), {
+              state: {
+                courseId,
+                stepOrder: activeRow.stepOrder,
+                name: activeRow.exercise.name,
+                imageSrc: activeRow.exercise.imageSrc,
+                step: { current: activeIndex + 1, total: exercises.length },
+              },
+            });
           }}
         >
           운동 시작하기

--- a/src/pages/exercise-detail/ui/ExerciseDetailPage.tsx
+++ b/src/pages/exercise-detail/ui/ExerciseDetailPage.tsx
@@ -3,7 +3,7 @@ import { useLocation, useNavigate, useParams } from "react-router";
 import { FALLBACK_POSE_IMAGE } from "@/entities/course";
 import { useExercise } from "@/entities/exercise";
 import { useStartSession } from "@/entities/session";
-import { toSessionPath } from "@/shared/config/routes";
+import { toDailyRoutinePath, toSessionPath } from "@/shared/config/routes";
 import { Button, CTAButton } from "@/shared/ui/button";
 import { CroppedWorkoutImage } from "@/shared/ui/cropped-workout-image";
 import { MuscleDiagram } from "@/shared/ui/muscle-diagram";
@@ -49,7 +49,16 @@ export function ExerciseDetailPage() {
 
   return (
     <main className="relative flex min-h-screen flex-col items-center px-[2rem] pb-[10rem]">
-      <TopNavBar onBack={() => navigate(-1)} className="w-full">
+      <TopNavBar
+        onBack={() => {
+          if (preview) {
+            navigate(toDailyRoutinePath(preview.courseId));
+          } else {
+            navigate(-1);
+          }
+        }}
+        className="w-full"
+      >
         <span className="typo-headline-emphasized text-black">데일리 루틴</span>
       </TopNavBar>
 

--- a/src/pages/my-edit/ui/MyEditPage.tsx
+++ b/src/pages/my-edit/ui/MyEditPage.tsx
@@ -27,7 +27,8 @@ export function MyEditPage() {
         <MyEditForm
           member={member}
           isEditingExperience={isEditingExperience}
-          onNavigateBack={() => navigate(-1)}
+          onNavigateBack={() => navigate(toMyPath())}
+          onBackFromExperience={() => navigate(ROUTES.myEdit)}
           onEditExperience={() => navigate(editStepPath("experience"))}
           onSaveSuccess={() => navigate(toMyPath(), { replace: true })}
         />
@@ -40,12 +41,14 @@ function MyEditForm({
   member,
   isEditingExperience,
   onNavigateBack,
+  onBackFromExperience,
   onEditExperience,
   onSaveSuccess,
 }: {
   member: Member;
   isEditingExperience: boolean;
   onNavigateBack: () => void;
+  onBackFromExperience: () => void;
   onEditExperience: () => void;
   onSaveSuccess: () => void;
 }) {
@@ -85,7 +88,7 @@ function MyEditForm({
       <ExperienceStep
         value={values.experienceLevel}
         onChange={handlers.updateExperienceLevel}
-        onBack={onNavigateBack}
+        onBack={onBackFromExperience}
       />
     );
   }

--- a/src/pages/pose-challenge/ui/PoseChallengePage.tsx
+++ b/src/pages/pose-challenge/ui/PoseChallengePage.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { useNavigate } from "react-router";
 import type { PoseChallengeStatus } from "@/entities/pose";
+import { ROUTES } from "@/shared/config/routes";
 import { cn } from "@/shared/lib/cn";
 import { Button } from "@/shared/ui/button";
 import { ErrorMessage } from "@/shared/ui/error-message";
@@ -33,7 +34,7 @@ export function PoseChallengePage() {
     return (
       <main className="relative flex min-h-screen flex-col items-center px-[2rem] pb-[8rem]">
         <TopNavBar
-          onBack={() => navigate(-1)}
+          onBack={() => navigate(ROUTES.home)}
           className="w-full"
           children={<span className="typo-headline-emphasized text-black">자세 도전 현황</span>}
         />
@@ -68,7 +69,7 @@ export function PoseChallengePage() {
   return (
     <main className="relative flex min-h-screen flex-col items-center px-[2rem] pb-[8rem]">
       <TopNavBar
-        onBack={() => navigate(-1)}
+        onBack={() => navigate(ROUTES.home)}
         className="w-full"
         children={<span className="typo-headline-emphasized text-black">자세 도전 현황</span>}
       />

--- a/src/pages/session/ui/SessionCountdownTimer.tsx
+++ b/src/pages/session/ui/SessionCountdownTimer.tsx
@@ -3,8 +3,7 @@ import sessionTimerBackdrop from "@/shared/assets/imgs/session/timer-backdrop.sv
 import { IconButton } from "@/shared/ui/button";
 import { NextIcon, PreviousIcon } from "@/shared/ui/icons";
 
-// Figma의 실제 링(Ellipse 4403 Stroke)은 곡선을 따라가는 점선이 아니라, 시계 눈금처럼
-// 중심을 향해 뻗은 직선 tick으로 이루어져 있다. viewBox는 168x84(원본 에셋 픽셀 크기)를 그대로 쓴다.
+// Figma의 실제 링(Ellipse 4403 Stroke)은 곡선을 따라가는 점선이 아니라, 시계 눈금처럼 중심을 향해 뻗은 직선 tick으로 이루어져 있다. viewBox는 168x84(원본 에셋 픽셀 크기)를 그대로 쓴다.
 const CENTER_X = 84;
 const CENTER_Y = 84;
 const OUTER_RADIUS = 80;
@@ -41,11 +40,23 @@ interface SessionCountdownTimerProps {
   totalSeconds: number;
   /** 타이머가 0에 도달하면 호출된다 */
   onFinish: () => void;
+  /** 이전 동작의 코스 상세로 이동한다 */
+  onPrevious?: () => void;
+  /** 다음 동작의 코스 상세로 이동한다 */
+  onNext?: () => void;
+  previousDisabled?: boolean;
+  nextDisabled?: boolean;
 }
 
-export function SessionCountdownTimer({ totalSeconds, onFinish }: SessionCountdownTimerProps) {
-  // 지나간 시간의 비율(0~1). 렌더 중에는 Date.now()나 ref를 직접 읽지 않고(impure),
-  // setInterval 콜백 안에서만 갱신한다.
+export function SessionCountdownTimer({
+  totalSeconds,
+  onFinish,
+  onPrevious,
+  onNext,
+  previousDisabled,
+  nextDisabled,
+}: SessionCountdownTimerProps) {
+  // 지나간 시간의 비율(0~1). 렌더 중에는 Date.now()나 ref를 직접 읽지 않고(impure), setInterval 콜백 안에서만 갱신한다.
   const [elapsedFraction, setElapsedFraction] = useState(0);
 
   useEffect(() => {
@@ -79,8 +90,13 @@ export function SessionCountdownTimer({ totalSeconds, onFinish }: SessionCountdo
       />
 
       <div className="relative z-10 flex w-full items-center justify-center gap-[2.4rem]">
-        {/* TODO: 세션 하나 = 동작 하나라 이전/다음이 지금은 할 일이 없다. 용도가 정해지면 연결한다. */}
-        <IconButton icon={PreviousIcon} aria-label="이전 동작" className="shrink-0 text-gray-80" />
+        <IconButton
+          icon={PreviousIcon}
+          aria-label="이전 동작"
+          onClick={onPrevious}
+          disabled={previousDisabled}
+          className="shrink-0 text-gray-80 disabled:opacity-40"
+        />
 
         <div className="relative h-[10.4rem] w-[20.8rem] shrink-0">
           <svg viewBox="0 0 168 84" fill="none" className="absolute inset-0 size-full">
@@ -107,7 +123,13 @@ export function SessionCountdownTimer({ totalSeconds, onFinish }: SessionCountdo
           </div>
         </div>
 
-        <IconButton icon={NextIcon} aria-label="다음 동작" className="shrink-0 text-gray-80" />
+        <IconButton
+          icon={NextIcon}
+          aria-label="다음 동작"
+          onClick={onNext}
+          disabled={nextDisabled}
+          className="shrink-0 text-gray-80 disabled:opacity-40"
+        />
       </div>
     </div>
   );

--- a/src/pages/session/ui/SessionPlayerPage.tsx
+++ b/src/pages/session/ui/SessionPlayerPage.tsx
@@ -1,10 +1,19 @@
 import { useMemo, useState } from "react";
 import { useNavigate, useParams } from "react-router";
+import {
+  findAdjacentExerciseRow,
+  useCourseDetailView,
+  type DailyRoutineExerciseRowView,
+} from "@/entities/course";
 import { useExercise } from "@/entities/exercise";
 import { useSession } from "@/entities/session";
 import sessionTimerGlow from "@/shared/assets/imgs/session/timer-glow.svg";
 import sessionWoodBg from "@/shared/assets/imgs/session/wood-bg.png";
-import { toCompletePath, toDailyRoutinePath } from "@/shared/config/routes";
+import {
+  toCompletePath,
+  toDailyRoutineExercisePath,
+  toDailyRoutinePath,
+} from "@/shared/config/routes";
 import { TopNavBar } from "@/shared/ui/top-nav-bar";
 import { getActiveVoiceCues } from "../api/active-voice-cues";
 import { useCompleteSession } from "../api/use-complete-session";
@@ -19,8 +28,10 @@ const DEFAULT_DURATION_SECONDS = 30;
 // exerciseRecords는 스키마상 배열이지만, 이 세션 안에서 여러 동작을 넘나드는 시나리오는 없다.
 //
 // 타이머가 끝나면 세션을 완료 처리하고, 이 코스 회차의 마지막 스텝이었을 때만(courseCompleted)
-// 완료 리포트(핀포즈 직후에만 뜨는 화면)로 보낸다. 아니면 다음 스텝을 고르도록 코스 순서 화면으로
-// 돌려보낸다 — 다른 자세를 하려면 밖에서 다시 "시작하기"를 눌러야 하기 때문이다.
+// 완료 리포트(핀포즈 직후에만 뜨는 화면)로 보낸다. 아니면 코스 상세를 다시 조회해 다음 운동을
+// 찾아 그 운동의 코스 상세 화면으로 보낸다 — 세션은 그 화면의 "운동 시작하기"를 눌러야 다시 시작된다.
+// 이전/다음 동작 버튼도 같은 방식으로, 방금 플레이 중인 스텝 기준 바로 옆 운동의 코스 상세로 보낸다
+// (세션을 시작/완료하지 않고 그냥 둘러보기만 한다).
 export function SessionPlayerPage() {
   const navigate = useNavigate();
   const params = useParams();
@@ -28,6 +39,7 @@ export function SessionPlayerPage() {
 
   const { data: session } = useSession(sessionId);
   const completeSession = useCompleteSession(sessionId as number);
+  const { data: courseDetail } = useCourseDetailView(session?.courseId ?? null);
   const [videoTime, setVideoTime] = useState(0);
 
   const exerciseRecords = useMemo(() => session?.exerciseRecords ?? [], [session]);
@@ -45,15 +57,74 @@ export function SessionPlayerPage() {
     totalSeconds,
   );
 
+  const navigateToExerciseDetail = (
+    courseId: number,
+    index: number,
+    row: DailyRoutineExerciseRowView,
+    total: number,
+  ) => {
+    navigate(toDailyRoutineExercisePath(String(row.exercise.exerciseId)), {
+      state: {
+        courseId,
+        stepOrder: row.stepOrder,
+        name: row.exercise.name,
+        imageSrc: row.exercise.imageSrc,
+        step: { current: index + 1, total },
+      },
+    });
+  };
+
+  const goToCourseDetail = () => {
+    if (!session?.courseId) return;
+    const currentIndex = courseDetail?.exercises.findIndex(
+      (row) => row.stepOrder === session.stepOrder,
+    );
+    if (courseDetail && currentIndex !== undefined && currentIndex !== -1) {
+      navigateToExerciseDetail(
+        session.courseId,
+        currentIndex,
+        courseDetail.exercises[currentIndex],
+        courseDetail.exercises.length,
+      );
+      return;
+    }
+    navigate(toDailyRoutinePath(session.courseId));
+  };
+
+  const goToAdjacentExercise = (direction: "previous" | "next") => {
+    if (!session?.courseId || !session?.stepOrder || !courseDetail) return;
+    const adjacent = findAdjacentExerciseRow(courseDetail.exercises, session.stepOrder, direction);
+    if (!adjacent) return;
+    navigateToExerciseDetail(
+      session.courseId,
+      adjacent.index,
+      adjacent.row,
+      courseDetail.exercises.length,
+    );
+  };
+
   const handleFinish = () => {
-    if (sessionId === null) return;
+    if (sessionId === null || !session?.courseId || !session?.stepOrder) return;
+    const courseId = session.courseId;
+    const playedStepOrder = session.stepOrder;
     completeSession.mutate(exerciseRecords, {
       onSuccess: (result) => {
         if (result.courseProgress?.courseCompleted) {
           navigate(toCompletePath(sessionId));
-        } else {
-          navigate(toDailyRoutinePath(result.courseId as number));
+          return;
         }
+
+        // 방금 마친 세션의 stepOrder 바로 다음 줄로 간다 — 전체 진행도(활성 스텝)와 무관하게,
+        // 예를 들어 5번째까지 진행된 상태에서 2번을 다시 플레이했으면 다음은 3번이어야 한다.
+        const next = courseDetail
+          ? findAdjacentExerciseRow(courseDetail.exercises, playedStepOrder, "next")
+          : null;
+        if (!next) {
+          navigate(toDailyRoutinePath(courseId));
+          return;
+        }
+
+        navigateToExerciseDetail(courseId, next.index, next.row, courseDetail!.exercises.length);
       },
     });
   };
@@ -62,10 +133,17 @@ export function SessionPlayerPage() {
     return null;
   }
 
+  const hasPreviousExercise = Boolean(
+    courseDetail && findAdjacentExerciseRow(courseDetail.exercises, session.stepOrder!, "previous"),
+  );
+  const hasNextExercise = Boolean(
+    courseDetail && findAdjacentExerciseRow(courseDetail.exercises, session.stepOrder!, "next"),
+  );
+
   return (
     <main className="relative flex min-h-screen flex-col bg-white">
       <TopNavBar
-        onBack={() => navigate(-1)}
+        onBack={goToCourseDetail}
         className="px-[2rem]"
         // TODO: 음소거 버튼 추가
         // rightIcon={SoundIcon}
@@ -120,7 +198,14 @@ export function SessionPlayerPage() {
             </div>
           )}
 
-          <SessionCountdownTimer totalSeconds={totalSeconds} onFinish={handleFinish} />
+          <SessionCountdownTimer
+            totalSeconds={totalSeconds}
+            onFinish={handleFinish}
+            onPrevious={() => goToAdjacentExercise("previous")}
+            onNext={() => goToAdjacentExercise("next")}
+            previousDisabled={!hasPreviousExercise}
+            nextDisabled={!hasNextExercise}
+          />
         </div>
       </div>
     </main>


### PR DESCRIPTION
## Summary

- 데일리 루틴(코스 목록)의 "운동 시작하기" CTA가 바로 세션을 시작하지 않고, 오늘의 운동 코스 상세(운동 상세) 페이지로 이동하도록 변경 — 세션은 그 페이지에서만 시작
- 세션 완료 시 다음 운동의 코스 상세로, 세션 플레이어의 이전/다음 버튼도 인접 운동의 코스 상세로 이동하도록 연결
- 코스 상세/세션 플레이어/자세 도전 현황/프로필 편집 페이지의 뒤로가기를 브라우저 히스토리(`navigate(-1)`) 대신 고정된 목적지로 이동하도록 변경

## Related Issues

- close #

## PR Point (To Reviewer)

- 코스 상세 매핑 로직(`mapCourseDetailResponse`)을 `pages/daily-routine`에서 `entities/course`로 옮겨 세션 플레이어와 공유하도록 했습니다. 다만 `pages/daily-routine/api/use-course.ts`는 아직 예전 방식(raw response + 수동 매핑)을 쓰고 있어 캐시 키가 두 갈래로 나뉘어 있습니다 — 후속 정리가 필요합니다.
- `doc.md`(v0.7 정책 문서) 기준으로 보면 세션 중 뒤로가기/이전·다음 버튼에 `PL-SES-012`(중단 확인 모달)가 빠져 있고, `PL-CRS-010`(동작 브리핑은 세션 흐름 안에 포함되어야 하며 별도 상세 페이지가 아님)과 설계 방향이 다릅니다. 이번 변경은 요청받은 네비게이션 동작을 우선 구현한 것이라, 정책 문서와의 정합성은 별도 논의가 필요해 보입니다.

## Screenshot

## ETC